### PR TITLE
feat: Implement time management module

### DIFF
--- a/apiService.ts
+++ b/apiService.ts
@@ -139,6 +139,51 @@ export const fetchAllTimeLogsAPI = (filters?: any): Promise<TimeLog[]> => { // F
     return apiFetch<TimeLog[]>(`/admin/timelogs${query ? `?${query}` : ''}`);
 };
 
+export const fetchMyTimeLogsAPI = (freelancerId: string, filters?: { dateFrom?: string, dateTo?: string, projectId?: string, jobCardId?: string }): Promise<TimeLog[]> => {
+  const queryParams = new URLSearchParams();
+  if (filters?.dateFrom) queryParams.append('dateFrom', filters.dateFrom);
+  if (filters?.dateTo) queryParams.append('dateTo', filters.dateTo);
+  if (filters?.projectId) queryParams.append('projectId', filters.projectId);
+  if (filters?.jobCardId) queryParams.append('jobCardId', filters.jobCardId);
+  const queryString = queryParams.toString();
+  return apiFetch<TimeLog[]>(`/users/${freelancerId}/timelogs${queryString ? `?${queryString}` : ''}`);
+};
+
+export const updateTimeLogAPI = (timeLogId: string, updates: Partial<Omit<TimeLog, 'id' | 'createdAt' | 'architectId' | 'jobCardId'>>): Promise<TimeLog> => {
+  return apiFetch<TimeLog>(`/timelogs/${timeLogId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(updates),
+  });
+};
+
+export const deleteTimeLogAPI = (timeLogId: string): Promise<void> => {
+  return apiFetch<void>(`/timelogs/${timeLogId}`, {
+    method: 'DELETE',
+  });
+};
+
+export const fetchClientProjectTimeLogsAPI = (clientId: string, projectId: string, filters?: { dateFrom?: string, dateTo?: string, freelancerId?: string }): Promise<TimeLog[]> => {
+  const queryParams = new URLSearchParams();
+  if (filters?.dateFrom) queryParams.append('dateFrom', filters.dateFrom);
+  if (filters?.dateTo) queryParams.append('dateTo', filters.dateTo);
+  if (filters?.freelancerId) queryParams.append('freelancerId', filters.freelancerId);
+  const queryString = queryParams.toString();
+  return apiFetch<TimeLog[]>(`/clients/${clientId}/projects/${projectId}/timelogs${queryString ? `?${queryString}` : ''}`);
+};
+
+export const adminUpdateTimeLogAPI = (timeLogId: string, updates: Partial<Omit<TimeLog, 'id' | 'createdAt'>>): Promise<TimeLog> => {
+  return apiFetch<TimeLog>(`/admin/timelogs/${timeLogId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(updates),
+  });
+};
+
+export const adminDeleteTimeLogAPI = (timeLogId: string): Promise<void> => {
+  return apiFetch<void>(`/admin/timelogs/${timeLogId}`, {
+    method: 'DELETE',
+  });
+};
+
 
 // --- File Service ---
 export const fetchProjectFilesAPI = (projectId: string): Promise<ManagedFile[]> => apiFetch<ManagedFile[]>(`/projects/${projectId}/files`);

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -15,7 +15,9 @@ import AdminTimeLogReportPage from './admin/AdminTimeLogReportPage';
 import ProjectBrowser from './freelancer/ProjectBrowser';
 import MyApplications from './freelancer/MyApplications';
 import MyJobCards from './freelancer/MyJobCards';
+import FreelancerTimeTrackingPage from './freelancer/FreelancerTimeTrackingPage';
 import MyProjects from './client/MyProjects'; 
+import ClientProjectTimeLogPage from './client/ClientProjectTimeLogPage'; // Import the new page
 import MessagingPage from './MessagingPage'; 
 import UserProfilePage from './UserProfilePage'; 
 import { NAV_LINKS } from '../constants';
@@ -41,11 +43,13 @@ const getSidebarNavItems = (role: UserRole): SidebarNavItem[] => {
         { label: 'Browse Projects', to: `${baseDashboardPath}/${NAV_LINKS.FREELANCER_BROWSE}`, icon: <BriefcaseIcon /> },
         { label: 'My Applications', to: `${baseDashboardPath}/${NAV_LINKS.FREELANCER_APPLICATIONS}`, icon: <DocumentTextIcon /> },
         { label: 'My Job Cards', to: `${baseDashboardPath}/${NAV_LINKS.FREELANCER_JOB_CARDS}`, icon: <ListBulletIcon /> },
+        { label: 'Time Tracking', to: `${baseDashboardPath}/${NAV_LINKS.FREELANCER_TIME_TRACKING}`, icon: <ClockIcon /> },
       ];
     case UserRole.CLIENT:
       return [
         { label: 'Overview', to: NAV_LINKS.DASHBOARD_OVERVIEW, icon: <HomeIcon /> },
         { label: 'My Projects', to: `${baseDashboardPath}/${NAV_LINKS.CLIENT_MY_PROJECTS}`, icon: <BriefcaseIcon /> },
+        { label: 'Project Time Logs', to: `${baseDashboardPath}/${NAV_LINKS.CLIENT_PROJECT_TIME_LOGS}`, icon: <ClockIcon /> },
       ];
     default:
       return [{ label: 'Overview', to: NAV_LINKS.DASHBOARD_OVERVIEW, icon: <HomeIcon /> }];
@@ -106,6 +110,7 @@ const Dashboard: React.FC = () => {
               <Route path={NAV_LINKS.FREELANCER_BROWSE} element={<ProjectBrowser />} />
               <Route path={NAV_LINKS.FREELANCER_APPLICATIONS} element={<MyApplications />} />
               <Route path={NAV_LINKS.FREELANCER_JOB_CARDS} element={<MyJobCards />} />
+              <Route path={NAV_LINKS.FREELANCER_TIME_TRACKING} element={<FreelancerTimeTrackingPage />} />
             </>
           )}
 
@@ -113,6 +118,7 @@ const Dashboard: React.FC = () => {
           {user.role === UserRole.CLIENT && (
             <>
               <Route path={NAV_LINKS.CLIENT_MY_PROJECTS} element={<MyProjects />} />
+              <Route path={NAV_LINKS.CLIENT_PROJECT_TIME_LOGS} element={<ClientProjectTimeLogPage />} />
             </>
           )}
           

--- a/components/admin/AdminTimeLogReportPage.test.tsx
+++ b/components/admin/AdminTimeLogReportPage.test.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { UserRole } from '../../types';
+import AdminTimeLogReportPage from './AdminTimeLogReportPage';
+import { useAuth } from '../AuthContext';
+import * as apiService from '../../apiService';
+
+// Mock API service
+jest.mock('../../apiService');
+const mockFetchAllTimeLogsAPI = apiService.fetchAllTimeLogsAPI as jest.Mock;
+const mockFetchAllProjectsWithTimeLogsAPI = apiService.fetchAllProjectsWithTimeLogsAPI as jest.Mock;
+const mockFetchUsersAPI = apiService.fetchUsersAPI as jest.Mock;
+const mockAdminDeleteTimeLogAPI = apiService.adminDeleteTimeLogAPI as jest.Mock;
+const mockAdminUpdateTimeLogAPI = apiService.adminUpdateTimeLogAPI as jest.Mock;
+
+// Mock AuthContext
+jest.mock('../AuthContext');
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+const mockAdminUser = { id: 'admin1', name: 'Admin User', role: UserRole.ADMIN };
+const mockProjects = [
+  {
+    id: 'proj1', title: 'Project X', clientId: 'client1',
+    jobCards: [{ id: 'jc1', title: 'Task X1', projectId: 'proj1' }]
+  },
+];
+const mockUsers = [
+  mockAdminUser,
+  { id: 'freelancer1', name: 'Freelancer A', role: UserRole.FREELANCER },
+  { id: 'client1', name: 'Client Alpha', role: UserRole.CLIENT },
+];
+const mockRawTimeLogs = [
+  { id: 'tl1', jobCardId: 'jc1', architectId: 'freelancer1', startTime: '2023-01-01T09:00:00.000Z', endTime: '2023-01-01T10:00:00.000Z', durationMinutes: 60, notes: 'Admin Log 1' },
+  { id: 'tl2', jobCardId: 'jc1', architectId: 'freelancer1', startTime: '2023-01-02T10:00:00.000Z', endTime: '2023-01-02T11:00:00.000Z', durationMinutes: 60, notes: 'Admin Log 2' },
+];
+
+// Enriched logs as would be processed by the component
+const mockEnrichedTimeLogs = mockRawTimeLogs.map(log => ({
+    ...log,
+    projectName: 'Project X',
+    jobCardTitle: 'Task X1',
+    architectName: 'Freelancer A',
+    clientName: 'Client Alpha'
+}));
+
+
+describe('AdminTimeLogReportPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      user: mockAdminUser,
+      token: 'test-token',
+      isLoading: false,
+      login: jest.fn(), logout: jest.fn(), updateCurrentUserDetails: jest.fn(),
+      activeTimerInfo: null, startGlobalTimer: jest.fn(), stopGlobalTimerAndLog: jest.fn(), clearGlobalTimerState: jest.fn(),
+    });
+
+    mockFetchAllTimeLogsAPI.mockResolvedValue([...mockRawTimeLogs]); // Use spread to avoid issues with direct modification
+    mockFetchAllProjectsWithTimeLogsAPI.mockResolvedValue(mockProjects);
+    mockFetchUsersAPI.mockResolvedValue(mockUsers);
+    mockAdminDeleteTimeLogAPI.mockResolvedValue(undefined);
+    mockAdminUpdateTimeLogAPI.mockResolvedValue(mockRawTimeLogs[0]); // Return some log on update
+    global.confirm = jest.fn(() => true); // Default confirm to true
+    window.alert = jest.fn(); // Mock alert
+  });
+
+  test('fetches and displays time logs with enriched data', async () => {
+    render(<AdminTimeLogReportPage />);
+    await waitFor(() => {
+      expect(mockFetchAllTimeLogsAPI).toHaveBeenCalled();
+      expect(mockFetchAllProjectsWithTimeLogsAPI).toHaveBeenCalled();
+      expect(mockFetchUsersAPI).toHaveBeenCalled();
+    });
+    expect(screen.getByText('Admin Log 1')).toBeInTheDocument();
+    expect(screen.getByText('Admin Log 2')).toBeInTheDocument();
+    expect(screen.getAllByText('Project X').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Task X1').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Freelancer A').length).toBeGreaterThan(0);
+  });
+
+  describe('Delete Time Log', () => {
+    test('successfully deletes a time log after confirmation', async () => {
+      render(<AdminTimeLogReportPage />);
+      await waitFor(() => expect(screen.getByText('Admin Log 1')).toBeInTheDocument());
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      fireEvent.click(deleteButtons[0]); // Click delete for the first log
+
+      expect(global.confirm).toHaveBeenCalledWith('Are you sure you want to delete this time log?');
+      expect(mockAdminDeleteTimeLogAPI).toHaveBeenCalledWith('tl1');
+
+      // Expect data to be re-fetched (dataVersion incremented, useEffect re-runs)
+      await waitFor(() => expect(mockFetchAllTimeLogsAPI).toHaveBeenCalledTimes(2));
+      expect(window.alert).toHaveBeenCalledWith('Time log deleted successfully.');
+    });
+
+    test('does not delete if confirmation is cancelled', async () => {
+      (global.confirm as jest.Mock).mockReturnValueOnce(false);
+      render(<AdminTimeLogReportPage />);
+      await waitFor(() => expect(screen.getByText('Admin Log 1')).toBeInTheDocument());
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      fireEvent.click(deleteButtons[0]);
+
+      expect(global.confirm).toHaveBeenCalledWith('Are you sure you want to delete this time log?');
+      expect(mockAdminDeleteTimeLogAPI).not.toHaveBeenCalled();
+    });
+
+    test('handles error during delete', async () => {
+      mockAdminDeleteTimeLogAPI.mockRejectedValueOnce(new Error('Delete failed'));
+      render(<AdminTimeLogReportPage />);
+      await waitFor(() => expect(screen.getByText('Admin Log 1')).toBeInTheDocument());
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      fireEvent.click(deleteButtons[0]);
+
+      await waitFor(() => expect(mockAdminDeleteTimeLogAPI).toHaveBeenCalledWith('tl1'));
+      expect(window.alert).toHaveBeenCalledWith('Error: Delete failed');
+    });
+  });
+
+  describe('Edit Time Log', () => {
+    test('opens edit modal with populated data on edit click', async () => {
+      render(<AdminTimeLogReportPage />);
+      await waitFor(() => expect(screen.getByText('Admin Log 1')).toBeInTheDocument());
+
+      const editButtons = screen.getAllByRole('button', { name: /edit/i });
+      fireEvent.click(editButtons[0]); // Edit first log
+
+      expect(screen.getByRole('heading', { name: /edit time log/i })).toBeInTheDocument();
+      expect(screen.getByLabelText(/date/i)).toHaveValue('2023-01-01');
+      expect(screen.getByLabelText(/start time/i)).toHaveValue('09:00');
+      expect(screen.getByLabelText(/end time/i)).toHaveValue('10:00');
+      expect(screen.getByLabelText(/notes/i)).toHaveValue('Admin Log 1');
+      expect(screen.getByLabelText(/job card id/i)).toHaveValue('jc1');
+      expect(screen.getByLabelText(/architect id/i)).toHaveValue('freelancer1');
+    });
+
+    test('successfully updates a time log', async () => {
+      render(<AdminTimeLogReportPage />);
+      await waitFor(() => expect(screen.getByText('Admin Log 1')).toBeInTheDocument());
+
+      fireEvent.click(screen.getAllByRole('button', { name: /edit/i })[0]); // Open modal
+
+      // Modify data
+      fireEvent.change(screen.getByLabelText(/notes/i), { target: { value: 'Updated Admin Log 1' } });
+      fireEvent.change(screen.getByLabelText(/end time/i), { target: { value: '10:30' } }); // Change end time
+
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => expect(mockAdminUpdateTimeLogAPI).toHaveBeenCalledWith(
+        'tl1',
+        expect.objectContaining({
+          notes: 'Updated Admin Log 1',
+          startTime: '2023-01-01T09:00:00.000Z', // Original start time
+          endTime: '2023-01-01T10:30:00.000Z',   // New end time
+          durationMinutes: 90, // Recalculated duration
+          jobCardId: 'jc1',
+          architectId: 'freelancer1',
+        })
+      ));
+      expect(window.alert).toHaveBeenCalledWith('Time log updated successfully.');
+      expect(screen.queryByRole('heading', { name: /edit time log/i })).not.toBeInTheDocument(); // Modal closes
+      expect(mockFetchAllTimeLogsAPI).toHaveBeenCalledTimes(2); // Refreshed
+    });
+
+    test('handles error during update', async () => {
+        mockAdminUpdateTimeLogAPI.mockRejectedValueOnce(new Error('Update failed'));
+        render(<AdminTimeLogReportPage />);
+        await waitFor(() => expect(screen.getByText('Admin Log 1')).toBeInTheDocument());
+
+        fireEvent.click(screen.getAllByRole('button', { name: /edit/i })[0]);
+        fireEvent.change(screen.getByLabelText(/notes/i), { target: { value: 'Attempted Update' } });
+        fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+        await waitFor(() => expect(mockAdminUpdateTimeLogAPI).toHaveBeenCalled());
+        expect(window.alert).toHaveBeenCalledWith('Error updating time log: Update failed');
+        // Modal should ideally stay open or show error within, but current implementation uses alert.
+    });
+
+    test('validation: end time must be after start time in edit modal', async () => {
+        render(<AdminTimeLogReportPage />);
+        await waitFor(() => expect(screen.getByText('Admin Log 1')).toBeInTheDocument());
+        fireEvent.click(screen.getAllByRole('button', { name: /edit/i })[0]);
+
+        fireEvent.change(screen.getByLabelText(/end time/i), { target: { value: '08:00' } }); // Start time is 09:00
+        fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+        expect(window.alert).toHaveBeenCalledWith('End time must be after start time.');
+        expect(mockAdminUpdateTimeLogAPI).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/components/admin/AdminTimeLogReportPage.tsx
+++ b/components/admin/AdminTimeLogReportPage.tsx
@@ -1,6 +1,12 @@
-import React, { useState, useEffect } from 'react';
-import { TimeLog, Project, User, UserRole } from '../../types';
-import { fetchAllProjectsWithTimeLogsAPI, fetchUsersAPI, fetchAllTimeLogsAPI } from '../../apiService';
+import React, { useState, useEffect, useCallback } from 'react';
+import { TimeLog, Project, User, UserRole, JobCard } from '../../types'; // Added JobCard
+import {
+  fetchAllProjectsWithTimeLogsAPI,
+  fetchUsersAPI,
+  fetchAllTimeLogsAPI,
+  adminDeleteTimeLogAPI, // Import delete API
+  adminUpdateTimeLogAPI, // Import update API
+} from '../../apiService';
 import LoadingSpinner from '../shared/LoadingSpinner';
 import { formatDurationToHHMMSS } from '../../constants';
 
@@ -25,45 +31,144 @@ const AdminTimeLogReportPage: React.FC = () => {
   const [filterStartDate, setFilterStartDate] = useState<string>('');
   const [filterEndDate, setFilterEndDate] = useState<string>('');
 
+  // State for editing
+  const [editingTimeLog, setEditingTimeLog] = useState<EnrichedTimeLog | null>(null);
+  const [showEditModal, setShowEditModal] = useState<boolean>(false);
+  // Edit form field states
+  const [editDate, setEditDate] = useState<string>('');
+  const [editStartTime, setEditStartTime] = useState<string>('');
+  const [editEndTime, setEditEndTime] = useState<string>('');
+  const [editNotes, setEditNotes] = useState<string>('');
+  const [editJobCardId, setEditJobCardId] = useState<string>(''); // Admin can edit this
+  const [editArchitectId, setEditArchitectId] = useState<string>(''); // Admin can edit this
+  // Add a state to trigger re-fetch
+  const [dataVersion, setDataVersion] = useState<number>(0);
+
+
+  const loadData = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const [fetchedLogs, fetchedProjects, fetchedUsers] = await Promise.all([
+          fetchAllTimeLogsAPI(),
+          fetchAllProjectsWithTimeLogsAPI(),
+          fetchUsersAPI()
+      ]);
+
+      setProjects(fetchedProjects);
+      setUsers(fetchedUsers);
+
+      const enrichedLogs: EnrichedTimeLog[] = fetchedLogs.map(log => {
+          const projectDetails = fetchedProjects.find(p => p.jobCards?.some(jc => jc.id === log.jobCardId));
+          const jobCardDetails = projectDetails?.jobCards?.find(jc => jc.id === log.jobCardId);
+          const architectDetails = fetchedUsers.find(u => u.id === log.architectId);
+          const clientDetails = projectDetails ? fetchedUsers.find(u => u.id === projectDetails.clientId) : undefined;
+          return {
+              ...log,
+              projectName: projectDetails?.title,
+              jobCardTitle: jobCardDetails?.title,
+              architectName: architectDetails?.name,
+              clientName: clientDetails?.name
+          };
+      });
+      setAllTimeLogs(enrichedLogs);
+
+    } catch (err: any) {
+      console.error("Failed to load time log data:", err);
+      setError(err.message || "Could not load time log reports.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []); // Keep original loadData dependency
+
   useEffect(() => {
-    const loadData = async () => {
-      setIsLoading(true);
-      setError(null);
-      try {
-        const [fetchedLogs, fetchedProjects, fetchedUsers] = await Promise.all([
-            fetchAllTimeLogsAPI(), // This API should ideally allow filtering on backend
-            fetchAllProjectsWithTimeLogsAPI(), // To get project info for dropdowns, context
-            fetchUsersAPI() // To get user names
-        ]);
-        
-        setProjects(fetchedProjects);
-        setUsers(fetchedUsers);
-
-        // Enrich logs with names - ideally backend would do most of this
-        const enrichedLogs: EnrichedTimeLog[] = fetchedLogs.map(log => {
-            const project = fetchedProjects.find(p => p.jobCards?.some(jc => jc.id === log.jobCardId));
-            const jobCard = project?.jobCards?.find(jc => jc.id === log.jobCardId);
-            const architect = fetchedUsers.find(u => u.id === log.architectId);
-            const client = project ? fetchedUsers.find(u => u.id === project.clientId) : undefined;
-            return {
-                ...log,
-                projectName: project?.title,
-                jobCardTitle: jobCard?.title,
-                architectName: architect?.name,
-                clientName: client?.name
-            };
-        });
-        setAllTimeLogs(enrichedLogs);
-
-      } catch (err: any) {
-        console.error("Failed to load time log data:", err);
-        setError(err.message || "Could not load time log reports.");
-      } finally {
-        setIsLoading(false);
-      }
-    };
     loadData();
-  }, []);
+  }, [dataVersion, loadData]); // Re-fetch when dataVersion changes or loadData definition changes (though it shouldn't)
+
+
+  const handleDeleteTimeLog = async (timeLogId: string) => {
+    if (window.confirm('Are you sure you want to delete this time log?')) {
+      try {
+        await adminDeleteTimeLogAPI(timeLogId);
+        setDataVersion(prev => prev + 1); // Trigger re-fetch
+        alert('Time log deleted successfully.');
+      } catch (err: any) {
+        console.error('Error deleting time log:', err);
+        setError(err.message || 'Failed to delete time log.');
+        alert(`Error: ${err.message || 'Failed to delete time log.'}`);
+      }
+    }
+  };
+
+  const handleOpenEditModal = (timeLog: EnrichedTimeLog) => {
+    setEditingTimeLog(timeLog);
+    const startDate = new Date(timeLog.startTime);
+    const endDate = new Date(timeLog.endTime);
+    setEditDate(startDate.toISOString().split('T')[0]);
+    setEditStartTime(`${startDate.getHours().toString().padStart(2, '0')}:${startDate.getMinutes().toString().padStart(2, '0')}`);
+    setEditEndTime(`${endDate.getHours().toString().padStart(2, '0')}:${endDate.getMinutes().toString().padStart(2, '0')}`);
+    setEditNotes(timeLog.notes || '');
+    setEditJobCardId(timeLog.jobCardId);
+    setEditArchitectId(timeLog.architectId);
+    setShowEditModal(true);
+  };
+
+  const handleCloseEditModal = () => {
+    setShowEditModal(false);
+    setEditingTimeLog(null);
+    // Optionally reset edit form fields here if not reset on open
+  };
+
+  // NOTE: The duplicated loadData definition was removed here.
+  // The correct one is the useCallback defined earlier, which is used in the useEffect hook.
+
+  const handleUpdateEditedTimeLog = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!editingTimeLog) {
+      setError("No time log selected for editing.");
+      return;
+    }
+
+    if (!editDate || !editStartTime || !editEndTime || !editJobCardId || !editArchitectId) {
+        alert("Please ensure Date, Start Time, End Time, Job Card ID, and Architect ID are filled.");
+        return;
+    }
+
+    const newStartTimeISO = new Date(`${editDate}T${editStartTime}:00`).toISOString();
+    const newEndTimeISO = new Date(`${editDate}T${editEndTime}:00`).toISOString();
+
+    if (new Date(newEndTimeISO) <= new Date(newStartTimeISO)) {
+      alert("End time must be after start time.");
+      return;
+    }
+
+    const durationMinutes = Math.round((new Date(newEndTimeISO).getTime() - new Date(newStartTimeISO).getTime()) / (1000 * 60));
+    if (durationMinutes <= 0 && !(editStartTime === editEndTime)) { // Allow 0 if start and end are same, for some edge cases.
+        alert("Duration must be positive or start/end times must be identical for zero duration.");
+        return;
+    }
+
+    const updates: Partial<Omit<TimeLog, 'id' | 'createdAt'>> = {
+      startTime: newStartTimeISO,
+      endTime: newEndTimeISO,
+      durationMinutes, // This is now calculated
+      notes: editNotes,
+      jobCardId: editJobCardId,
+      architectId: editArchitectId,
+      // manualEntry is not directly editable here, assume it's preserved or backend handles if it's part of TimeLog Omit
+    };
+
+    try {
+      await adminUpdateTimeLogAPI(editingTimeLog.id, updates);
+      setDataVersion(prev => prev + 1); // Trigger re-fetch
+      handleCloseEditModal();
+      alert('Time log updated successfully.');
+    } catch (err: any) {
+      console.error('Error updating time log:', err);
+      // setError(err.message || 'Failed to update time log.'); // This would show global error
+      alert(`Error updating time log: ${err.message || 'Failed to update time log.'}`); // Simple alert for now
+    }
+  };
 
   const clients = users.filter(u => u.role === UserRole.CLIENT);
   const freelancers = users.filter(u => u.role === UserRole.FREELANCER);
@@ -125,6 +230,53 @@ const AdminTimeLogReportPage: React.FC = () => {
           <p className="text-center text-gray-500 py-8">No time logs match the current filters or no time logs available.</p>
       )}
 
+      {showEditModal && editingTimeLog && (
+        <div style={{ position: 'fixed', top: 0, left: 0, width: '100%', height: '100%', backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex', justifyContent: 'center', alignItems: 'center', zIndex: 1000 }}>
+          <div style={{ backgroundColor: 'white', padding: '25px', borderRadius: '8px', boxShadow: '0 4px 15px rgba(0,0,0,0.2)', width: '90%', maxWidth: '500px' }}>
+            <h3 className="text-xl font-semibold mb-4">Edit Time Log</h3>
+            <form onSubmit={handleUpdateEditedTimeLog}>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                <div>
+                  <label htmlFor="editDate" className="block text-sm font-medium text-gray-700">Date</label>
+                  <input type="date" id="editDate" value={editDate} onChange={e => setEditDate(e.target.value)} required className="mt-1 block w-full p-2 border-gray-300 rounded-md shadow-sm"/>
+                </div>
+                <div> {/* Placeholder div for alignment if needed, or more fields */} </div>
+                <div>
+                  <label htmlFor="editStartTime" className="block text-sm font-medium text-gray-700">Start Time</label>
+                  <input type="time" id="editStartTime" value={editStartTime} onChange={e => setEditStartTime(e.target.value)} required className="mt-1 block w-full p-2 border-gray-300 rounded-md shadow-sm"/>
+                </div>
+                <div>
+                  <label htmlFor="editEndTime" className="block text-sm font-medium text-gray-700">End Time</label>
+                  <input type="time" id="editEndTime" value={editEndTime} onChange={e => setEditEndTime(e.target.value)} required className="mt-1 block w-full p-2 border-gray-300 rounded-md shadow-sm"/>
+                </div>
+                <div>
+                  <label htmlFor="editJobCardId" className="block text-sm font-medium text-gray-700">Job Card ID</label>
+                  <input type="text" id="editJobCardId" value={editJobCardId} onChange={e => setEditJobCardId(e.target.value)} required className="mt-1 block w-full p-2 border-gray-300 rounded-md shadow-sm"/>
+                  <p className="text-xs text-gray-500 mt-1">Caution: Ensure this ID is valid.</p>
+                </div>
+                <div>
+                  <label htmlFor="editArchitectId" className="block text-sm font-medium text-gray-700">Architect ID</label>
+                  <input type="text" id="editArchitectId" value={editArchitectId} onChange={e => setEditArchitectId(e.target.value)} required className="mt-1 block w-full p-2 border-gray-300 rounded-md shadow-sm"/>
+                   <p className="text-xs text-gray-500 mt-1">Caution: Ensure this ID is valid.</p>
+                </div>
+              </div>
+              <div className="mb-4">
+                <label htmlFor="editNotes" className="block text-sm font-medium text-gray-700">Notes</label>
+                <textarea id="editNotes" value={editNotes} onChange={e => setEditNotes(e.target.value)} rows={3} className="mt-1 block w-full p-2 border-gray-300 rounded-md shadow-sm"></textarea>
+              </div>
+              <div className="flex justify-end space-x-3">
+                <button type="button" onClick={handleCloseEditModal} className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-200 hover:bg-gray-300 rounded-md">
+                  Cancel
+                </button>
+                <button type="submit" className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-md">
+                  Save Changes
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
       {filteredLogs.length > 0 && (
         <div className="overflow-x-auto rounded-lg border border-gray-200">
             <table className="min-w-full divide-y divide-gray-200">
@@ -137,6 +289,7 @@ const AdminTimeLogReportPage: React.FC = () => {
                         <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Freelancer</th>
                         <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Duration</th>
                         <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Notes</th>
+                        <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                     </tr>
                 </thead>
                 <tbody className="bg-white divide-y divide-gray-200">
@@ -145,10 +298,24 @@ const AdminTimeLogReportPage: React.FC = () => {
                             <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-600">{new Date(log.startTime).toLocaleDateString()}</td>
                             <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-600">{log.clientName || '-'}</td>
                             <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-600">{log.projectName || '-'}</td>
-                            <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-600">{log.jobCardTitle || '-'}</td>
-                            <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-600">{log.architectName || '-'}</td>
+                            <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-600">{log.jobCardTitle || `ID: ${log.jobCardId}`}</td>
+                            <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-600">{log.architectName || `ID: ${log.architectId}`}</td>
                             <td className="px-4 py-2 whitespace-nowrap text-sm text-gray-600">{formatDurationToHHMMSS(log.durationMinutes * 60)}</td>
                             <td className="px-4 py-2 text-sm text-gray-600 max-w-xs truncate" title={log.notes}>{log.notes || '-'}</td>
+                            <td className="px-4 py-2 whitespace-nowrap text-sm font-medium">
+                                <button
+                                    onClick={() => handleOpenEditModal(log)}
+                                    className="text-indigo-600 hover:text-indigo-900 mr-3 px-2 py-1 border border-indigo-600 rounded-md text-xs"
+                                >
+                                    Edit
+                                </button>
+                                <button
+                                    onClick={() => handleDeleteTimeLog(log.id)}
+                                    className="text-red-600 hover:text-red-900 px-2 py-1 border border-red-600 rounded-md text-xs"
+                                >
+                                    Delete
+                                </button>
+                            </td>
                         </tr>
                     ))}
                 </tbody>

--- a/components/client/ClientProjectTimeLogPage.test.tsx
+++ b/components/client/ClientProjectTimeLogPage.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { UserRole } from '../../types';
+import ClientProjectTimeLogPage from './ClientProjectTimeLogPage';
+import { useAuth } from '../AuthContext';
+import * as apiService from '../../apiService';
+
+// Mock API service
+jest.mock('../../apiService');
+const mockFetchProjectsAPI = apiService.fetchProjectsAPI as jest.Mock;
+const mockFetchUsersAPI = apiService.fetchUsersAPI as jest.Mock;
+const mockFetchClientProjectTimeLogsAPI = apiService.fetchClientProjectTimeLogsAPI as jest.Mock;
+
+// Mock AuthContext
+jest.mock('../AuthContext');
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+const mockClientProjects = [
+  { id: 'proj1', title: 'Project Alpha', clientId: 'client1', description: '', budget: 0, deadline: '', skillsRequired: [], status: 'Open' },
+  { id: 'proj2', title: 'Project Beta', clientId: 'client1', description: '', budget: 0, deadline: '', skillsRequired: [], status: 'Open' },
+];
+
+const mockFreelancerUsers = [
+  { id: 'freelancer1', name: 'John Doe', role: UserRole.FREELANCER },
+  { id: 'freelancer2', name: 'Jane Smith', role: UserRole.FREELANCER },
+];
+
+const mockTimeLogsForProj1 = [
+  { id: 'tl1', jobCardId: 'jc1', architectId: 'freelancer1', startTime: new Date().toISOString(), endTime: new Date().toISOString(), durationMinutes: 60, notes: 'Work on Alpha feature 1' },
+  { id: 'tl2', jobCardId: 'jc2', architectId: 'freelancer2', startTime: new Date().toISOString(), endTime: new Date().toISOString(), durationMinutes: 120, notes: 'Work on Alpha feature 2' },
+];
+
+describe('ClientProjectTimeLogPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      user: { id: 'client1', name: 'Client User', role: UserRole.CLIENT },
+      token: 'test-token',
+      isLoading: false,
+      // Provide all required fields for AuthContextType, even if not directly used in this component
+      login: jest.fn(),
+      logout: jest.fn(),
+      updateCurrentUserDetails: jest.fn(),
+      activeTimerInfo: null,
+      startGlobalTimer: jest.fn(),
+      stopGlobalTimerAndLog: jest.fn(),
+      clearGlobalTimerState: jest.fn(),
+    });
+
+    mockFetchProjectsAPI.mockResolvedValue(mockClientProjects);
+    mockFetchUsersAPI.mockResolvedValue(mockFreelancerUsers);
+    mockFetchClientProjectTimeLogsAPI.mockResolvedValue([]); // Default to no logs
+  });
+
+  test('renders loading state for projects initially', () => {
+    mockFetchProjectsAPI.mockImplementationOnce(() => new Promise(() => {})); // Keep it pending
+    render(<ClientProjectTimeLogPage />);
+    expect(screen.getByText(/loading projects.../i)).toBeInTheDocument();
+  });
+
+  test('fetches and displays client projects in dropdown', async () => {
+    render(<ClientProjectTimeLogPage />);
+    await waitFor(() => expect(mockFetchProjectsAPI).toHaveBeenCalledWith({ clientId: 'client1' }));
+    await waitFor(() => expect(mockFetchUsersAPI).toHaveBeenCalledWith(UserRole.FREELANCER));
+
+    expect(screen.getByRole('combobox', { name: /select project/i })).toBeInTheDocument();
+    expect(screen.getByText('Project Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Project Beta')).toBeInTheDocument();
+  });
+
+  test('displays "no projects" message if client has no projects', async () => {
+    mockFetchProjectsAPI.mockResolvedValueOnce([]);
+    render(<ClientProjectTimeLogPage />);
+    await waitFor(() => expect(screen.getByText(/you have no projects/i)).toBeInTheDocument());
+  });
+
+  test('fetches and displays time logs when a project is selected', async () => {
+    mockFetchClientProjectTimeLogsAPI.mockResolvedValueOnce(mockTimeLogsForProj1);
+    render(<ClientProjectTimeLogPage />);
+    await waitFor(() => screen.getByText('Project Alpha')); // Wait for projects to load
+
+    fireEvent.change(screen.getByRole('combobox', { name: /select project/i }), { target: { value: 'proj1' } });
+
+    await waitFor(() => expect(mockFetchClientProjectTimeLogsAPI).toHaveBeenCalledWith('client1', 'proj1'));
+    expect(screen.getByText(/work on alpha feature 1/i)).toBeInTheDocument();
+    expect(screen.getByText(/work on alpha feature 2/i)).toBeInTheDocument();
+    // Check for freelancer name mapping
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    // Check for job card ID display
+    expect(screen.getByText('Job Card ID: jc1')).toBeInTheDocument();
+    expect(screen.getByText('Job Card ID: jc2')).toBeInTheDocument();
+  });
+
+  test('displays loading state for time logs', async () => {
+    render(<ClientProjectTimeLogPage />);
+    await waitFor(() => screen.getByText('Project Alpha'));
+
+    mockFetchClientProjectTimeLogsAPI.mockImplementationOnce(() => new Promise(() => {})); // Keep pending
+    fireEvent.change(screen.getByRole('combobox', { name: /select project/i }), { target: { value: 'proj1' } });
+
+    expect(screen.getByText(/loading time logs.../i)).toBeInTheDocument();
+  });
+
+  test('displays "no time logs" message if selected project has no logs', async () => {
+    mockFetchClientProjectTimeLogsAPI.mockResolvedValueOnce([]); // Ensure it resolves to empty
+    render(<ClientProjectTimeLogPage />);
+    await waitFor(() => screen.getByText('Project Alpha'));
+
+    fireEvent.change(screen.getByRole('combobox', { name: /select project/i }), { target: { value: 'proj1' } });
+
+    await waitFor(() => expect(mockFetchClientProjectTimeLogsAPI).toHaveBeenCalledWith('client1', 'proj1'));
+    expect(screen.getByText(/no time logs have been recorded for this project yet/i)).toBeInTheDocument();
+  });
+
+  test('displays error message if fetching projects fails', async () => {
+    mockFetchProjectsAPI.mockRejectedValueOnce(new Error('Failed to fetch projects'));
+    render(<ClientProjectTimeLogPage />);
+    await waitFor(() => expect(screen.getByText(/error: failed to fetch projects/i)).toBeInTheDocument());
+  });
+
+  test('displays error message if fetching time logs fails', async () => {
+    mockFetchClientProjectTimeLogsAPI.mockRejectedValueOnce(new Error('Failed to fetch logs'));
+    render(<ClientProjectTimeLogPage />);
+    await waitFor(() => screen.getByText('Project Alpha'));
+
+    fireEvent.change(screen.getByRole('combobox', { name: /select project/i }), { target: { value: 'proj1' } });
+    await waitFor(() => expect(screen.getByText(/error loading time logs: failed to fetch logs/i)).toBeInTheDocument());
+  });
+});

--- a/components/client/ClientProjectTimeLogPage.tsx
+++ b/components/client/ClientProjectTimeLogPage.tsx
@@ -1,0 +1,186 @@
+import React, { useState, useEffect, useContext } from 'react';
+import { User, Project, TimeLog, JobCard, UserRole } from '../../types'; // Assuming JobCard might be needed for titles
+import {
+  fetchProjectsAPI,
+  fetchClientProjectTimeLogsAPI,
+  fetchUsersAPI // For fetching users to map architectId to name
+} from '../../apiService';
+import { AuthContext } from '../AuthContext';
+// import { SomeSpinnerComponent } from '../shared/LoadingSpinner'; // Placeholder for a spinner
+
+const ClientProjectTimeLogPage: React.FC = () => {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [timeLogs, setTimeLogs] = useState<TimeLog[]>([]);
+  const [users, setUsers] = useState<User[]>([]); // To map architectId to freelancer name
+
+  const [isLoadingProjects, setIsLoadingProjects] = useState<boolean>(true);
+  const [isLoadingTimeLogs, setIsLoadingTimeLogs] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const auth = useContext(AuthContext);
+  const clientId = auth?.user?.id;
+  const clientRole = auth?.user?.role;
+
+  // Effect to fetch initial data: projects and users (freelancers)
+  useEffect(() => {
+    if (!clientId) {
+      setError("Client ID not found. Please log in again.");
+      setIsLoadingProjects(false);
+      return;
+    }
+    if (clientRole !== UserRole.CLIENT) {
+        setError("Access Denied. This page is for clients only.");
+        setIsLoadingProjects(false);
+        return;
+    }
+
+    const loadInitialData = async () => {
+      setIsLoadingProjects(true);
+      setError(null);
+      try {
+        const [fetchedProjects, fetchedUsers] = await Promise.all([
+          fetchProjectsAPI({ clientId }),
+          fetchUsersAPI(UserRole.FREELANCER) // Fetch only freelancers
+        ]);
+        setProjects(fetchedProjects);
+        setUsers(fetchedUsers);
+      } catch (err) {
+        console.error("Error fetching initial data:", err);
+        setError(err instanceof Error ? err.message : "An unknown error occurred while fetching projects or users.");
+      } finally {
+        setIsLoadingProjects(false);
+      }
+    };
+    loadInitialData();
+  }, [clientId, clientRole]);
+
+  // Effect to fetch time logs when a project is selected
+  useEffect(() => {
+    if (!selectedProjectId || !clientId) {
+      setTimeLogs([]); // Clear previous logs if no project is selected
+      return;
+    }
+
+    const loadTimeLogs = async () => {
+      setIsLoadingTimeLogs(true);
+      setError(null); // Clear previous errors specific to time log fetching
+      try {
+        const fetchedTimeLogs = await fetchClientProjectTimeLogsAPI(clientId, selectedProjectId);
+        setTimeLogs(fetchedTimeLogs);
+      } catch (err) {
+        console.error(`Error fetching time logs for project ${selectedProjectId}:`, err);
+        setError(err instanceof Error ? err.message : `Failed to fetch time logs for project ${selectedProjectId}.`);
+        setTimeLogs([]); // Clear time logs on error
+      } finally {
+        setIsLoadingTimeLogs(false);
+      }
+    };
+    loadTimeLogs();
+  }, [selectedProjectId, clientId]);
+
+  // Helper function to get freelancer name
+  const getFreelancerName = (architectId: string): string => {
+    const user = users.find(u => u.id === architectId);
+    return user ? user.name : `ID: ${architectId}`; // Fallback to ID if name not found
+  };
+
+  // Helper to get Job Card Title (placeholder for now)
+  const getJobCardDisplayInfo = (jobCardId: string): string => {
+    // In a real scenario, you might fetch job cards for the project
+    // and find the title, or the API would include jobCardTitle in TimeLog.
+    return `Job Card ID: ${jobCardId}`;
+  };
+
+
+  // Render early if role is incorrect (already handled by ProtectedView, but good for direct component use sense)
+   if (clientRole !== UserRole.CLIENT && !auth?.isLoading) { // isLoading check to prevent flash of this message
+    return <p>Access Denied. This page is for clients only.</p>;
+  }
+
+  if (isLoadingProjects) {
+    return <p>Loading projects...</p>; // Replace with a proper spinner
+  }
+
+  if (error && !selectedProjectId) { // Show general errors if no project is selected yet, or project loading failed
+    return <p>Error: {error}</p>;
+  }
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <h1>Project Time Logs</h1>
+
+      <div style={{ marginBottom: '20px' }}>
+        <label htmlFor="project-select" style={{ marginRight: '10px' }}>Select Project:</label>
+        <select
+          id="project-select"
+          value={selectedProjectId || ''}
+          onChange={e => setSelectedProjectId(e.target.value || null)}
+          style={{ padding: '8px', minWidth: '200px', border: '1px solid #ccc', borderRadius: '4px' }}
+          disabled={projects.length === 0}
+        >
+          <option value="">-- Select a Project --</option>
+          {projects.map(project => (
+            <option key={project.id} value={project.id}>{project.title}</option>
+          ))}
+        </select>
+        {projects.length === 0 && !isLoadingProjects && <p>You have no projects.</p>}
+      </div>
+
+      {selectedProjectId && (
+        <section>
+          <h2>Time Logs for: {projects.find(p => p.id === selectedProjectId)?.title || ''}</h2>
+          {isLoadingTimeLogs && <p>Loading time logs...</p> /* Replace with spinner */}
+          {!isLoadingTimeLogs && error && <p>Error loading time logs: {error}</p>}
+          {!isLoadingTimeLogs && !error && timeLogs.length === 0 && (
+            <p>No time logs have been recorded for this project yet.</p>
+          )}
+          {!isLoadingTimeLogs && !error && timeLogs.length > 0 && (
+            <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '20px' }}>
+              <thead>
+                <tr>
+                  <th style={tableHeaderStyle}>Date</th>
+                  <th style={tableHeaderStyle}>Freelancer</th>
+                  <th style={tableHeaderStyle}>Job Card</th>
+                  <th style={tableHeaderStyle}>Duration</th>
+                  <th style={tableHeaderStyle}>Notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                {timeLogs.map(log => (
+                  <tr key={log.id}>
+                    <td style={tableCellStyle}>{new Date(log.startTime).toLocaleDateString()}</td>
+                    <td style={tableCellStyle}>{getFreelancerName(log.architectId)}</td>
+                    <td style={tableCellStyle}>{getJobCardDisplayInfo(log.jobCardId)}</td>
+                    <td style={tableCellStyle}>{log.durationMinutes} min</td>
+                    <td style={tableCellStyle}>{log.notes || '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+      )}
+      {!selectedProjectId && !isLoadingProjects && projects.length > 0 && (
+        <p style={{ marginTop: '20px' }}>Please select a project to view its time logs.</p>
+      )}
+    </div>
+  );
+};
+
+// Basic styles (can be moved to a CSS file or styled components later)
+const tableHeaderStyle: React.CSSProperties = {
+  borderBottom: '2px solid #ddd',
+  padding: '10px',
+  textAlign: 'left',
+  backgroundColor: '#f9f9f9',
+  fontWeight: 'bold',
+};
+
+const tableCellStyle: React.CSSProperties = {
+  borderBottom: '1px solid #eee',
+  padding: '10px',
+  textAlign: 'left',
+};
+
+export default ClientProjectTimeLogPage;

--- a/components/freelancer/FreelancerTimeTrackingPage.test.tsx
+++ b/components/freelancer/FreelancerTimeTrackingPage.test.tsx
@@ -1,0 +1,204 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { UserRole } from '../../types';
+import FreelancerTimeTrackingPage from './FreelancerTimeTrackingPage';
+import { useAuth } from '../AuthContext';
+import * as apiService from '../../apiService';
+
+// Mock API service
+jest.mock('../../apiService');
+const mockFetchFreelancerJobCardsAPI = apiService.fetchFreelancerJobCardsAPI as jest.Mock;
+const mockFetchMyTimeLogsAPI = apiService.fetchMyTimeLogsAPI as jest.Mock;
+const mockAddTimeLogAPI = apiService.addTimeLogAPI as jest.Mock; // Used by manual log
+
+// Mock AuthContext
+jest.mock('../AuthContext');
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+const mockJobCards = [
+  { id: 'jc1', title: 'Job Card 1', projectId: 'proj1', description: 'Description 1', status: 'ToDo' },
+  { id: 'jc2', title: 'Job Card 2', projectId: 'proj2', description: 'Description 2', status: 'InProgress' },
+];
+
+const mockTimeLogs = [
+  { id: 'tl1', jobCardId: 'jc1', architectId: 'freelancer1', startTime: new Date().toISOString(), endTime: new Date().toISOString(), durationMinutes: 60, notes: 'Log 1', manualEntry: false },
+];
+
+describe('FreelancerTimeTrackingPage', () => {
+  let mockStartGlobalTimer: jest.Mock;
+  let mockStopGlobalTimerAndLog: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStartGlobalTimer = jest.fn();
+    mockStopGlobalTimerAndLog = jest.fn().mockResolvedValue(undefined); // Mock it as an async function
+
+    mockUseAuth.mockReturnValue({
+      user: { id: 'freelancer1', name: 'Freelancer User', role: UserRole.FREELANCER },
+      token: 'test-token',
+      isLoading: false,
+      login: jest.fn(),
+      logout: jest.fn(),
+      updateCurrentUserDetails: jest.fn(),
+      activeTimerInfo: null,
+      startGlobalTimer: mockStartGlobalTimer,
+      stopGlobalTimerAndLog: mockStopGlobalTimerAndLog,
+      clearGlobalTimerState: jest.fn(),
+    });
+
+    mockFetchFreelancerJobCardsAPI.mockResolvedValue(mockJobCards);
+    mockFetchMyTimeLogsAPI.mockResolvedValue(mockTimeLogs);
+    mockAddTimeLogAPI.mockResolvedValue({ id: 'newLog', ...mockTimeLogs[0] }); // Mock successful manual log
+  });
+
+  test('renders loading state initially', () => {
+    mockUseAuth.mockReturnValueOnce({ // Override for this specific test
+        ...mockUseAuth(),
+        isLoading: true, // Auth loading
+    });
+    render(<FreelancerTimeTrackingPage />);
+    expect(screen.getByText(/loading page data.../i)).toBeInTheDocument();
+  });
+
+  test('displays fetched job cards and time logs correctly', async () => {
+    render(<FreelancerTimeTrackingPage />);
+    await waitFor(() => expect(mockFetchFreelancerJobCardsAPI).toHaveBeenCalledWith('freelancer1'));
+    await waitFor(() => expect(mockFetchMyTimeLogsAPI).toHaveBeenCalledWith('freelancer1'));
+
+    expect(screen.getByText('Job Card 1 (Project ID: proj1)')).toBeInTheDocument();
+    expect(screen.getByText('Job Card 2 (Project ID: proj2)')).toBeInTheDocument();
+    expect(screen.getByText('Log 1')).toBeInTheDocument(); // Check if notes are rendered
+  });
+
+  test('displays "no job cards" message if none are returned', async () => {
+    mockFetchFreelancerJobCardsAPI.mockResolvedValueOnce([]);
+    render(<FreelancerTimeTrackingPage />);
+    await waitFor(() => expect(screen.getByText(/no job cards assigned to you yet/i)).toBeInTheDocument());
+  });
+
+  describe('Timer Functionality (Global Context)', () => {
+    test('clicking "Start Timer" calls startGlobalTimer from context', async () => {
+      render(<FreelancerTimeTrackingPage />);
+      await waitFor(() => screen.getByText('Job Card 1 (Project ID: proj1)'));
+
+      const startButtons = screen.getAllByText('Start Timer');
+      fireEvent.click(startButtons[0]); // Click start for Job Card 1
+
+      expect(mockStartGlobalTimer).toHaveBeenCalledWith('jc1', 'Job Card 1', 'proj1');
+    });
+
+    test('displays "Stop Timer" for the active job card from context', async () => {
+      mockUseAuth.mockReturnValueOnce({
+        ...mockUseAuth(),
+        activeTimerInfo: { jobCardId: 'jc1', jobCardTitle: 'Job Card 1', projectId: 'proj1', startTime: new Date() },
+      });
+      render(<FreelancerTimeTrackingPage />);
+      await waitFor(() => screen.getByText('Job Card 1 (Project ID: proj1)'));
+
+      const buttons = screen.getAllByRole('button');
+      // Find the button related to Job Card 1
+      const jobCard1Li = screen.getByText('Job Card 1 (Project ID: proj1)').closest('li');
+      const stopButtonForJC1 = Array.from(jobCard1Li!.querySelectorAll('button')).find(b => b.textContent?.includes('Stop Timer'));
+      expect(stopButtonForJC1).toBeInTheDocument();
+
+      // Check that other job cards still show "Start Timer" or are disabled
+      const jobCard2Li = screen.getByText('Job Card 2 (Project ID: proj2)').closest('li');
+      const startButtonForJC2 = Array.from(jobCard2Li!.querySelectorAll('button')).find(b => b.textContent?.includes('Start Timer'));
+      expect(startButtonForJC2).toHaveStyle('cursor: not-allowed'); // Or check if disabled
+    });
+
+    test('clicking "Stop Timer" calls stopGlobalTimerAndLog from context', async () => {
+      window.prompt = jest.fn().mockReturnValue(''); // Mock prompt for notes
+
+      mockUseAuth.mockReturnValueOnce({
+        ...mockUseAuth(),
+        activeTimerInfo: { jobCardId: 'jc1', jobCardTitle: 'Job Card 1', projectId: 'proj1', startTime: new Date() },
+      });
+      render(<FreelancerTimeTrackingPage />);
+      await waitFor(() => screen.getByText('Job Card 1 (Project ID: proj1)'));
+
+      const jobCard1Li = screen.getByText('Job Card 1 (Project ID: proj1)').closest('li');
+      const stopButtonForJC1 = Array.from(jobCard1Li!.querySelectorAll('button')).find(b => b.textContent?.includes('Stop Timer'));
+      fireEvent.click(stopButtonForJC1!);
+
+      expect(mockStopGlobalTimerAndLog).toHaveBeenCalledWith(undefined); // Called with undefined notes as prompt returns ''
+      await waitFor(() => expect(mockFetchMyTimeLogsAPI).toHaveBeenCalledTimes(2)); // Initial + refresh after stop
+    });
+  });
+
+  describe('Manual Time Log', () => {
+    test('modal opens on "Log Time Manually" click', async () => {
+      render(<FreelancerTimeTrackingPage />);
+      await waitFor(() => screen.getByText('Job Card 1 (Project ID: proj1)'));
+
+      const manualLogButtons = screen.getAllByText('Log Time Manually');
+      fireEvent.click(manualLogButtons[0]);
+
+      expect(screen.getByRole('heading', { name: /log time manually for: job card 1/i })).toBeInTheDocument();
+      expect(screen.getByLabelText(/date/i)).toBeInTheDocument();
+    });
+
+    test('form submission calls addTimeLogAPI and refreshes logs', async () => {
+        render(<FreelancerTimeTrackingPage />);
+        await waitFor(() => screen.getByText('Job Card 1 (Project ID: proj1)'));
+
+        fireEvent.click(screen.getAllByText('Log Time Manually')[0]); // Open for jc1
+
+        // Fill form
+        fireEvent.change(screen.getByLabelText(/date/i), { target: { value: '2023-10-01' } });
+        fireEvent.change(screen.getByLabelText(/start time/i), { target: { value: '09:00' } });
+        fireEvent.change(screen.getByLabelText(/end time/i), { target: { value: '10:00' } });
+        fireEvent.change(screen.getByLabelText(/notes/i), { target: { value: 'Manual log test' } });
+
+        fireEvent.click(screen.getByRole('button', {name: /submit log/i}));
+
+        await waitFor(() => expect(mockAddTimeLogAPI).toHaveBeenCalledWith(
+          'proj1', // projectId for jc1
+          'jc1',   // jobCardId
+          expect.objectContaining({
+            startTime: new Date('2023-10-01T09:00:00').toISOString(),
+            endTime: new Date('2023-10-01T10:00:00').toISOString(),
+            durationMinutes: 60,
+            notes: 'Manual log test',
+            manualEntry: true,
+            architectId: 'freelancer1',
+          })
+        ));
+        expect(screen.queryByRole('heading', { name: /log time manually for: job card 1/i })).not.toBeInTheDocument(); // Modal closes
+        expect(mockFetchMyTimeLogsAPI).toHaveBeenCalledTimes(2); // Initial + refresh
+    });
+
+    test('shows error on addTimeLogAPI failure', async () => {
+        mockAddTimeLogAPI.mockRejectedValueOnce(new Error('API Error Manual Log'));
+        window.alert = jest.fn(); // Mock alert for error messages
+
+        render(<FreelancerTimeTrackingPage />);
+        await waitFor(() => screen.getByText('Job Card 1 (Project ID: proj1)'));
+        fireEvent.click(screen.getAllByText('Log Time Manually')[0]);
+        fireEvent.change(screen.getByLabelText(/date/i), { target: { value: '2023-10-01' } });
+        fireEvent.change(screen.getByLabelText(/start time/i), { target: { value: '09:00' } });
+        fireEvent.change(screen.getByLabelText(/end time/i), { target: { value: '10:00' } });
+        fireEvent.click(screen.getByRole('button', {name: /submit log/i}));
+
+        await waitFor(() => expect(window.alert).toHaveBeenCalledWith(expect.stringContaining('API Error Manual Log')));
+        window.alert = jest.fn(); // Clear mock for other tests
+    });
+
+    test('shows validation error for end time before start time', async () => {
+        window.alert = jest.fn();
+        render(<FreelancerTimeTrackingPage />);
+        await waitFor(() => screen.getByText('Job Card 1 (Project ID: proj1)'));
+        fireEvent.click(screen.getAllByText('Log Time Manually')[0]);
+
+        fireEvent.change(screen.getByLabelText(/date/i), { target: { value: '2023-10-01' } });
+        fireEvent.change(screen.getByLabelText(/start time/i), { target: { value: '10:00' } });
+        fireEvent.change(screen.getByLabelText(/end time/i), { target: { value: '09:00' } });
+        fireEvent.click(screen.getByRole('button', {name: /submit log/i}));
+
+        expect(window.alert).toHaveBeenCalledWith('End time must be after start time.');
+        expect(mockAddTimeLogAPI).not.toHaveBeenCalled();
+        window.alert = jest.fn();
+    });
+  });
+});

--- a/components/freelancer/FreelancerTimeTrackingPage.tsx
+++ b/components/freelancer/FreelancerTimeTrackingPage.tsx
@@ -1,0 +1,354 @@
+import React, { useState, useEffect, useContext } from 'react'; // Removed unused 'useContext' if AuthContext import changes to useAuth hook
+import { User, JobCard, TimeLog } from '../../types';
+import {
+  fetchFreelancerJobCardsAPI,
+  fetchMyTimeLogsAPI,
+  // addTimeLogAPI, // Will be handled by AuthContext's stopGlobalTimerAndLog
+  deleteTimeLogAPI, // Keep for future direct delete on this page
+  updateTimeLogAPI  // Keep for future direct edit on this page
+} from '../../apiService';
+// import { AuthContext } from '../AuthContext'; // No longer directly used, useAuth hook instead
+import { useAuth } from '../AuthContext'; // Import useAuth
+
+const FreelancerTimeTrackingPage: React.FC = () => {
+  const [jobCards, setJobCards] = useState<JobCard[]>([]);
+  const [timeLogs, setTimeLogs] = useState<TimeLog[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true); // For page data loading
+  const [isProcessingLog, setIsProcessingLog] = useState<boolean>(false); // For log submission spinner
+  const [error, setError] = useState<string | null>(null);
+  // const [activeTimer, setActiveTimer] = useState<{ jobCardId: string, startTime: Date } | null>(null); // REMOVED - Use global timer from AuthContext
+  const [manualLogJobCardId, setManualLogJobCardId] = useState<string | null>(null);
+
+  const { user, activeTimerInfo, startGlobalTimer, stopGlobalTimerAndLog, isLoading: isAuthLoading } = useAuth(); // Get global timer state and functions
+  const freelancerId = user?.id;
+
+
+  // State for manual log form
+  const [manualDate, setManualDate] = useState<string>(new Date().toISOString().split('T')[0]);
+  const [manualStartTime, setManualStartTime] = useState<string>('09:00');
+  const [manualEndTime, setManualEndTime] = useState<string>('17:00');
+  const [manualNotes, setManualNotes] = useState<string>('');
+
+
+  // const auth = useContext(AuthContext); // REMOVED
+  // const freelancerId = auth?.user?.id; // Now from useAuth().user.id
+
+  useEffect(() => {
+    if (!freelancerId && !isAuthLoading) { // Wait for auth to load
+      setError("User ID not found. Please ensure you are logged in.");
+      setIsLoading(false);
+      return;
+    }
+    if(freelancerId){
+      const fetchData = async () => {
+        setIsLoading(true);
+        setError(null);
+        try {
+          // Fetch job cards and existing time logs when freelancerId is available
+          const [fetchedJobCards, fetchedTimeLogs] = await Promise.all([
+            fetchFreelancerJobCardsAPI(freelancerId),
+            fetchMyTimeLogsAPI(freelancerId) // Consider filtering by activeTimerInfo.jobCardId if needed
+          ]);
+          setJobCards(fetchedJobCards);
+          setTimeLogs(fetchedTimeLogs);
+        } catch (err) {
+          console.error("Error fetching page data:", err);
+          setError(err instanceof Error ? err.message : "An unknown error occurred while fetching data.");
+        } finally {
+          setIsLoading(false);
+        }
+      };
+      fetchData();
+    }
+  }, [freelancerId, isAuthLoading]);
+
+  // Effect to refresh time logs if a global timer was stopped elsewhere
+  useEffect(() => {
+    if (freelancerId && !activeTimerInfo && !isLoading) { // If timer was running and now it's not
+        const refreshLogs = async () => {
+            // This could be more sophisticated, e.g. checking if the last log was recent
+            // For now, just re-fetch if timer becomes null
+            // console.log("Global timer stopped, refreshing logs on tracking page.");
+            // setIsProcessingLog(true); // Show a brief loading state for logs
+            try {
+                const fetchedTimeLogs = await fetchMyTimeLogsAPI(freelancerId);
+                setTimeLogs(fetchedTimeLogs);
+            } catch (err) {
+                console.error("Error refreshing time logs:", err);
+                // setError("Failed to refresh time logs after timer stop.");
+            } finally {
+                // setIsProcessingLog(false);
+            }
+        };
+        // Only run if there was an active timer previously (requires more complex state tracking or rely on other signals)
+        // This simple version might over-fetch. For now, this is disabled to prevent over-fetching.
+        // A better approach might be an event bus or callback from AuthContext.
+        // refreshLogs();
+    }
+  }, [activeTimerInfo, freelancerId, isLoading]);
+
+  // Helper functions for rendering
+  const getProjectTitle = (projectId: string): string => {
+    // This is a placeholder. Ideally, project data would be more readily available.
+    // For now, we don't have a list of all projects on this page.
+    // We could enhance JobCard type or fetch projects if this becomes critical.
+    // Consider if jobCards fetched could include projectTitle directly from backend.
+    return `Project ID: ${projectId}`;
+  };
+
+  const getJobCardTitle = (jobCardId: string): string => {
+    const card = jobCards.find(jc => jc.id === jobCardId);
+    return card ? card.title : 'Unknown Job Card';
+  };
+
+  const calculateTotalTimeForJobCard = (jobCardId: string): string => {
+    const totalMinutes = timeLogs
+      .filter(log => log.jobCardId === jobCardId)
+      .reduce((sum, log) => sum + log.durationMinutes, 0);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    return `${hours}h ${minutes}m`;
+  };
+
+  const handleStartTimer = (jobCard: JobCard) => { // Takes full JobCard object
+    if (activeTimerInfo) {
+      alert("Another timer is already active globally. Please stop it before starting a new one.");
+      return;
+    }
+    if (!freelancerId) {
+      alert("User ID not found. Cannot start timer.");
+      return;
+    }
+    // Use AuthContext to start the global timer
+    startGlobalTimer(jobCard.id, jobCard.title, jobCard.projectId);
+  };
+
+  const handlePageStopTimer = async () => {
+    if (!activeTimerInfo || !freelancerId) {
+      setError("No active timer to stop or user ID not found.");
+      return;
+    }
+    const notes = prompt("Optional notes for this time entry (or leave blank):");
+    setIsProcessingLog(true);
+    try {
+      await stopGlobalTimerAndLog(notes || undefined); // stopGlobalTimerAndLog handles API call and clearing activeTimerInfo
+      // Refresh time logs after stopping
+      const fetchedTimeLogs = await fetchMyTimeLogsAPI(freelancerId);
+      setTimeLogs(fetchedTimeLogs);
+      // alert("Timer stopped and time logged successfully!"); // Already handled by global timer logic potentially
+    } catch (err) {
+      console.error("Error stopping timer from page:", err);
+      setError(err instanceof Error ? err.message : "Failed to stop and log time.");
+      alert(`Error: ${err instanceof Error ? err.message : "Failed to stop and log time."}`);
+    } finally {
+      setIsProcessingLog(false);
+    }
+  };
+
+  const handleOpenManualLog = (jobCardId: string) => {
+    setManualLogJobCardId(jobCardId);
+    // Reset form fields when opening
+    setManualDate(new Date().toISOString().split('T')[0]);
+    setManualStartTime('09:00');
+    setManualEndTime('17:00');
+    setManualNotes('');
+  };
+
+  const handleCloseManualLog = () => {
+    setManualLogJobCardId(null);
+  };
+
+  const handleManualLogSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!manualLogJobCardId || !freelancerId) {
+      alert("Error: Job card ID or freelancer ID is missing.");
+      return;
+    }
+
+    if (!manualDate || !manualStartTime || !manualEndTime) {
+      alert("Please fill in date, start time, and end time.");
+      return;
+    }
+
+    const startTimeISO = new Date(`${manualDate}T${manualStartTime}:00`).toISOString();
+    const endTimeISO = new Date(`${manualDate}T${manualEndTime}:00`).toISOString();
+
+    if (new Date(endTimeISO) <= new Date(startTimeISO)) {
+      alert("End time must be after start time.");
+      return;
+    }
+
+    const durationMinutes = Math.round((new Date(endTimeISO).getTime() - new Date(startTimeISO).getTime()) / (1000 * 60));
+    if (durationMinutes <= 0) {
+        alert("Duration must be positive.");
+        return;
+    }
+
+    const jobCard = jobCards.find(jc => jc.id === manualLogJobCardId);
+    if (!jobCard) {
+      alert(`Project ID for Job Card ${manualLogJobCardId} not found.`);
+      setError(`Project ID for Job Card ${manualLogJobCardId} not found.`);
+      return;
+    }
+    const projectId = jobCard.projectId;
+
+    const newLogData: Omit<TimeLog, 'id' | 'createdAt'> = {
+      jobCardId: manualLogJobCardId,
+      architectId: freelancerId,
+      startTime: startTimeISO,
+      endTime: endTimeISO,
+      durationMinutes,
+      notes: manualNotes || undefined,
+      manualEntry: true,
+    };
+
+    setIsLoading(true);
+    try {
+      await addTimeLogAPI(projectId, manualLogJobCardId, newLogData);
+      handleCloseManualLog();
+      const fetchedTimeLogs = await fetchMyTimeLogsAPI(freelancerId);
+      setTimeLogs(fetchedTimeLogs);
+      alert("Manual time log added successfully!");
+    } catch (err) {
+      console.error("Error adding manual time log:", err);
+      setError(err instanceof Error ? err.message : "Failed to add manual log.");
+      alert(`Error: ${err instanceof Error ? err.message : "Failed to add manual log."}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Combined loading state check
+  if (isLoading || (isAuthLoading && !freelancerId)) return <p>Loading page data...</p>;
+  if (error) return <p>Error: {error}</p>;
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <h1>My Time Logs</h1>
+
+      <section>
+        <h2>Job Cards</h2>
+        {jobCards.length === 0 && !isLoading ? (
+          <p>No job cards assigned to you yet.</p>
+        ) : (
+          <ul style={{ listStyle: 'none', padding: 0 }}>
+            {jobCards.map(card => (
+              <li key={card.id} style={{ marginBottom: '20px', padding: '10px', border: '1px solid #ccc' }}>
+                <h3>{card.title} ({getProjectTitle(card.projectId)})</h3>
+                {/* <p>{getProjectTitle(card.projectId)}</p> */}
+                <p>Total Time Logged: {calculateTotalTimeForJobCard(card.id)}</p>
+                <button
+                  onClick={() => activeTimerInfo?.jobCardId === card.id ? handlePageStopTimer() : handleStartTimer(card)}
+                  style={{
+                    marginRight: '10px',
+                    backgroundColor: activeTimerInfo?.jobCardId === card.id ? 'red' : (activeTimerInfo ? '#ccc' : 'green'), // Grey out if other timer active
+                    color: 'white',
+                    cursor: activeTimerInfo && activeTimerInfo.jobCardId !== card.id ? 'not-allowed' : 'pointer'
+                  }}
+                  disabled={(activeTimerInfo && activeTimerInfo.jobCardId !== card.id) || isProcessingLog}
+                >
+                  {activeTimerInfo?.jobCardId === card.id
+                    ? (isProcessingLog ? 'Logging...' : 'Stop Timer')
+                    : 'Start Timer'}
+                </button>
+                <button
+                  onClick={() => handleOpenManualLog(card.id)}
+                  disabled={!!activeTimerInfo || !!manualLogJobCardId || isProcessingLog}
+                >
+                  Log Time Manually
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {manualLogJobCardId && (
+        <div style={{ position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', backgroundColor: 'white', padding: '30px', border: '1px solid #ccc', boxShadow: '0 4px 8px rgba(0,0,0,0.1)', zIndex: 1000 }}>
+          <h3>Log Time Manually for: {getJobCardTitle(manualLogJobCardId)}</h3>
+          <form onSubmit={handleManualLogSubmit}>
+            <div style={{ marginBottom: '10px' }}>
+              <label htmlFor="manualDate">Date: </label>
+              <input type="date" id="manualDate" value={manualDate} onChange={e => setManualDate(e.target.value)} required style={{ padding: '8px', border: '1px solid #ccc', borderRadius: '4px' }} />
+            </div>
+            <div style={{ marginBottom: '10px' }}>
+              <label htmlFor="manualStartTime">Start Time: </label>
+              <input type="time" id="manualStartTime" value={manualStartTime} onChange={e => setManualStartTime(e.target.value)} required style={{ padding: '8px', border: '1px solid #ccc', borderRadius: '4px' }} />
+            </div>
+            <div style={{ marginBottom: '10px' }}>
+              <label htmlFor="manualEndTime">End Time: </label>
+              <input type="time" id="manualEndTime" value={manualEndTime} onChange={e => setManualEndTime(e.target.value)} required style={{ padding: '8px', border: '1px solid #ccc', borderRadius: '4px' }} />
+            </div>
+            <div style={{ marginBottom: '15px' }}>
+              <label htmlFor="manualNotes">Notes (Optional): </label>
+              <textarea id="manualNotes" value={manualNotes} onChange={e => setManualNotes(e.target.value)} rows={3} style={{ width: 'calc(100% - 18px)', padding: '8px', border: '1px solid #ccc', borderRadius: '4px' }} />
+            </div>
+            <div style={{ textAlign: 'right' }}>
+              <button type="button" onClick={handleCloseManualLog} style={{ marginRight: '10px', padding: '10px 15px', backgroundColor: '#eee', border: 'none', borderRadius: '4px', cursor: 'pointer' }}>Cancel</button>
+              <button type="submit" disabled={isProcessingLog} style={{ padding: '10px 15px', backgroundColor: '#007bff', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer' }}>
+                {isProcessingLog ? 'Submitting...' : 'Submit Log'}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+      {manualLogJobCardId && <div style={{ position: 'fixed', top: 0, left: 0, width: '100%', height: '100%', backgroundColor: 'rgba(0,0,0,0.5)', zIndex: 999 }} onClick={handleCloseManualLog}></div> /* Modal Backdrop */}
+
+
+      <section style={{ marginTop: '30px' }}>
+        <h2>My Logged Time Entries</h2>
+        {timeLogs.length === 0 ? (
+          <p>You have not logged any time yet.</p>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                <th style={tableHeaderStyle}>Date</th>
+                <th style={tableHeaderStyle}>Project</th>
+                <th style={tableHeaderStyle}>Job Card</th>
+                <th style={tableHeaderStyle}>Start Time</th>
+                <th style={tableHeaderStyle}>End Time</th>
+                <th style={tableHeaderStyle}>Duration</th>
+                <th style={tableHeaderStyle}>Notes</th>
+                <th style={tableHeaderStyle}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {timeLogs.map(log => (
+                <tr key={log.id}>
+                  <td style={tableCellStyle}>{new Date(log.startTime).toLocaleDateString()}</td>
+                  <td style={tableCellStyle}>{getProjectTitle(jobCards.find(jc => jc.id === log.jobCardId)?.projectId || 'N/A')}</td>
+                  <td style={tableCellStyle}>{getJobCardTitle(log.jobCardId)}</td>
+                  <td style={tableCellStyle}>{new Date(log.startTime).toLocaleTimeString()}</td>
+                  <td style={tableCellStyle}>{new Date(log.endTime).toLocaleTimeString()}</td>
+                  <td style={tableCellStyle}>{log.durationMinutes} min</td>
+                  <td style={tableCellStyle}>{log.notes || '-'}</td>
+                  <td style={tableCellStyle}>
+                    <button onClick={() => alert('Edit log ' + log.id)} style={{ marginRight: '5px' }}>Edit</button>
+                    <button onClick={() => alert('Delete log ' + log.id)}>Delete</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+};
+
+// Basic styles (can be moved to a CSS file or styled components later)
+const tableHeaderStyle: React.CSSProperties = {
+  borderBottom: '2px solid #ddd',
+  padding: '8px',
+  textAlign: 'left',
+  backgroundColor: '#f7f7f7',
+};
+
+const tableCellStyle: React.CSSProperties = {
+  borderBottom: '1px solid #eee',
+  padding: '8px',
+  textAlign: 'left',
+};
+
+export default FreelancerTimeTrackingPage;

--- a/components/shared/GlobalTimerDisplay.test.tsx
+++ b/components/shared/GlobalTimerDisplay.test.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { UserRole } from '../../types';
+import GlobalTimerDisplay from './GlobalTimerDisplay';
+import { useAuth, ActiveTimerInfo } from '../AuthContext'; // Import ActiveTimerInfo type
+import * as constants from '../../constants';
+
+// Mock AuthContext
+jest.mock('../AuthContext');
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+// Mock constants or specific functions if they are complex
+jest.mock('../../constants', () => ({
+  ...jest.requireActual('../../constants'), // Import and retain default behavior
+  formatDurationToHHMMSS: jest.fn((totalSeconds: number) => {
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = Math.floor(totalSeconds % 60);
+    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  }),
+}));
+const mockFormatDurationToHHMMSS = constants.formatDurationToHHMMSS as jest.Mock;
+
+
+describe('GlobalTimerDisplay', () => {
+  let mockStopGlobalTimerAndLog: jest.Mock;
+  const mockUser = { id: 'freelancer1', name: 'Freelancer User', role: UserRole.FREELANCER };
+
+  beforeEach(() => {
+    jest.useFakeTimers(); // Use fake timers for interval testing
+    jest.clearAllMocks();
+    mockStopGlobalTimerAndLog = jest.fn().mockResolvedValue(undefined);
+    mockFormatDurationToHHMMSS.mockClear(); // Clear mock usage counts for format function
+
+    // Default AuthContext mock
+    mockUseAuth.mockReturnValue({
+      user: mockUser,
+      activeTimerInfo: null,
+      stopGlobalTimerAndLog: mockStopGlobalTimerAndLog,
+      // Provide all required AuthContextType fields
+      token: 'test-token',
+      isLoading: false,
+      login: jest.fn(),
+      logout: jest.fn(),
+      updateCurrentUserDetails: jest.fn(),
+      startGlobalTimer: jest.fn(),
+      clearGlobalTimerState: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers(); // Restore real timers after each test
+  });
+
+  test('renders nothing if activeTimerInfo is null', () => {
+    render(<GlobalTimerDisplay />);
+    // The component itself renders a div, but it has specific classes when visible.
+    // A more robust check might be for specific content that only appears when timer is active.
+    // For now, checking for a specific text like "ACTIVE TIMER" which is only there when timer is active.
+    expect(screen.queryByText(/active timer/i)).not.toBeInTheDocument();
+  });
+
+  test('renders nothing if user is not a freelancer', () => {
+    mockUseAuth.mockReturnValueOnce({
+      ...mockUseAuth(),
+      user: { id: 'admin1', name: 'Admin User', role: UserRole.ADMIN }, // Not a freelancer
+      activeTimerInfo: { jobCardId: 'jc1', jobCardTitle: 'Test Job', projectId: 'p1', startTime: new Date() } as ActiveTimerInfo,
+    });
+    render(<GlobalTimerDisplay />);
+    expect(screen.queryByText(/active timer/i)).not.toBeInTheDocument();
+  });
+
+  test('displays timer info and stop button when timer is active for a freelancer', () => {
+    const startTime = new Date(new Date().getTime() - 5000); // 5 seconds ago
+    mockFormatDurationToHHMMSS.mockReturnValue('00:00:05'); // Mock formatted output
+
+    mockUseAuth.mockReturnValueOnce({
+      ...mockUseAuth(),
+      activeTimerInfo: { jobCardId: 'jc1', jobCardTitle: 'Test Job Card Title', projectId: 'p1', startTime } as ActiveTimerInfo,
+    });
+    render(<GlobalTimerDisplay />);
+
+    expect(screen.getByText(/active timer/i)).toBeInTheDocument();
+    expect(screen.getByText('Test Job Card Title')).toBeInTheDocument();
+    expect(screen.getByText('00:00:05')).toBeInTheDocument(); // Check for mocked elapsed time
+    expect(screen.getByRole('button', { name: /stop/i })).toBeInTheDocument();
+  });
+
+  test('updates elapsed time every second', () => {
+    const startTime = new Date();
+    mockUseAuth.mockReturnValueOnce({
+        ...mockUseAuth(),
+        activeTimerInfo: { jobCardId: 'jc1', jobCardTitle: 'Test Job', projectId: 'p1', startTime } as ActiveTimerInfo,
+    });
+    render(<GlobalTimerDisplay />);
+
+    mockFormatDurationToHHMMSS.mockReturnValueOnce('00:00:00'); // Initial
+    expect(screen.getByText('00:00:00')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1000); // Advance timer by 1 second
+    });
+    mockFormatDurationToHHMMSS.mockReturnValueOnce('00:00:01'); // After 1 sec
+    // We need to re-query as the text content changes
+    expect(screen.getByText('00:00:01')).toBeInTheDocument();
+    expect(mockFormatDurationToHHMMSS).toHaveBeenCalledWith(1);
+
+
+    act(() => {
+      jest.advanceTimersByTime(1000); // Advance timer by another 1 second
+    });
+    mockFormatDurationToHHMMSS.mockReturnValueOnce('00:00:02'); // After 2 secs
+    expect(screen.getByText('00:00:02')).toBeInTheDocument();
+    expect(mockFormatDurationToHHMMSS).toHaveBeenCalledWith(2);
+  });
+
+  test('calls stopGlobalTimerAndLog on stop button click', async () => {
+    window.prompt = jest.fn().mockReturnValue('User notes'); // Mock prompt for notes
+    const startTime = new Date();
+    mockUseAuth.mockReturnValueOnce({
+      ...mockUseAuth(),
+      activeTimerInfo: { jobCardId: 'jc1', jobCardTitle: 'Test Job', projectId: 'p1', startTime } as ActiveTimerInfo,
+    });
+    render(<GlobalTimerDisplay />);
+
+    const stopButton = screen.getByRole('button', { name: /stop/i });
+    fireEvent.click(stopButton);
+
+    await waitFor(() => expect(mockStopGlobalTimerAndLog).toHaveBeenCalledWith('User notes'));
+  });
+
+  test('clears interval on unmount', () => {
+    const clearIntervalSpy = jest.spyOn(window, 'clearInterval');
+    const startTime = new Date();
+     mockUseAuth.mockReturnValueOnce({
+      ...mockUseAuth(),
+      activeTimerInfo: { jobCardId: 'jc1', jobCardTitle: 'Test Job', projectId: 'p1', startTime } as ActiveTimerInfo,
+    });
+    const { unmount } = render(<GlobalTimerDisplay />);
+    unmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+
+   test('clears interval when activeTimerInfo becomes null', () => {
+    const clearIntervalSpy = jest.spyOn(window, 'clearInterval');
+    const startTime = new Date();
+    const initialAuthValue = {
+      ...mockUseAuth(),
+      activeTimerInfo: { jobCardId: 'jc1', jobCardTitle: 'Test Job', projectId: 'p1', startTime } as ActiveTimerInfo,
+    };
+    mockUseAuth.mockReturnValue(initialAuthValue); // Use mockReturnValue to allow updates
+
+    const { rerender } = render(<GlobalTimerDisplay />);
+
+    // Timer is active, interval should be set
+    expect(clearIntervalSpy).not.toHaveBeenCalled();
+
+    // Update context value to simulate timer stopping
+    mockUseAuth.mockReturnValue({ ...initialAuthValue, activeTimerInfo: null });
+    rerender(<GlobalTimerDisplay />); // Rerender with new context value
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+
+});

--- a/components/shared/Navbar.tsx
+++ b/components/shared/Navbar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
+import GlobalTimerDisplay from './GlobalTimerDisplay'; // Import the GlobalTimerDisplay
 import Button from './Button';
 import { SHORT_APP_NAME, NAV_LINKS } from '../../constants'; 
 import { HomeIcon, UserCircleIcon, ChatBubbleLeftRightIcon, LogoutIcon, BriefcaseIcon, IconProps } from './IconComponents'; 
@@ -17,6 +18,8 @@ const Navbar: React.FC = () => {
 
   return (
     <nav className="bg-white text-text-dark shadow-md sticky top-0 z-50 border-b border-primary-extralight">
+      {/* GlobalTimerDisplay will be fixed position, so its location in DOM tree here is not super critical for layout */}
+      <GlobalTimerDisplay />
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           <div className="flex items-center">

--- a/constants.ts
+++ b/constants.ts
@@ -36,9 +36,11 @@ export const NAV_LINKS = {
   PUBLIC_PROJECT_BROWSE: '/browse-projects',
   FREELANCER_APPLICATIONS: 'my-applications',
   FREELANCER_JOB_CARDS: 'my-job-cards',
+  FREELANCER_TIME_TRACKING: 'time-tracking', // New link for freelancer time tracking
   
   CLIENT_MY_PROJECTS: 'my-projects', 
-  
+  CLIENT_PROJECT_TIME_LOGS: 'project-time-logs', // New link for client project time logs viewing
+
   PROJECT_DETAILS: '/project/:id', 
 };
 


### PR DESCRIPTION
I've implemented a comprehensive time management module. This will allow freelancers to track their time, clients to view the time spent on their projects, and admins to manage all time logs.

Here are the key features:

- **Freelancer Time Tracking:**
  - Freelancers can start and stop timers for specific job cards.
  - Manual time entry is also supported.
  - There's a dedicated page (`FreelancerTimeTrackingPage`) where freelancers can see their assigned job cards and time logs.
  - A global timer display (`GlobalTimerDisplay`) is visible in the navbar when a timer is active.
  - The timer's state is managed globally via `AuthContext`.

- **Client Time Viewing:**
  - Clients now have a new page (`ClientProjectTimeLogPage`) to view the time logged on their projects.
  - They can see time logs per project, with details like the freelancer, job card, duration, and any notes.

- **Admin Time Management:**
  - The existing `AdminTimeLogReportPage` has been enhanced.
  - Admins can now edit and delete any time log entry.
  - An edit modal allows for the modification of time log details.

- **API and Types:**
  - I've updated `apiService.ts` with new endpoints for fetching, adding, updating, and deleting time logs for different roles.
  - The existing types in `types.ts` were suitable for these changes.

- **Unit Tests:**
  - I've added comprehensive unit tests for all new and significantly modified components to ensure reliability and maintainability.