### PR TITLE
I've implemented the client dashboard statistics display.

### DIFF
--- a/apiService.ts
+++ b/apiService.ts
@@ -968,16 +968,28 @@ export interface AdminDashboardStatsResponse {
   total_open_applications: number;
 }
 
+// Stats for Client Dashboard
+export interface ClientDashboardStats {
+  myProjectsCount: number;
+  openProjectsCount: number; // Platform-wide
+  myInProgressProjectsCount: number;
+  myCompletedProjectsCount: number;
+}
+
 export const fetchAdminDashboardStatsAPI = (): Promise<AdminDashboardStatsResponse> => {
   return apiFetch<AdminDashboardStatsResponse>(`/api.php?action=get_admin_dashboard_stats`, {
     method: 'GET',
   }, true); // Requires Admin Auth
 };
 
-export const fetchFreelancerDashboardStatsAPI = (userId: string): Promise<any> => apiFetch<any>(`/users/${userId}/dashboard/stats`);
-export const fetchClientDashboardStatsAPI = (userId: string): Promise<any> => apiFetch<any>(`/users/${userId}/dashboard/stats`);
-export const fetchRecentActivityAPI = (userId: string): Promise<any[]> => apiFetch<any[]>(`/users/${userId}/recent-activity`);
-export const fetchAdminRecentFilesAPI = (): Promise<ManagedFile[]> => apiFetch<ManagedFile[]>(`/admin/recent-files`);
+export const fetchFreelancerDashboardStatsAPI = (userId: string): Promise<any> => apiFetch<any>(`/users/${userId}/dashboard/stats`); // Placeholder
+export const fetchClientDashboardStatsAPI = (): Promise<ClientDashboardStats> => {
+  return apiFetch<ClientDashboardStats>(`/api.php?action=get_client_dashboard_stats`, {
+    method: 'GET',
+  }, true); // Requires Client Auth
+};
+export const fetchRecentActivityAPI = (userId: string): Promise<any[]> => apiFetch<any[]>(`/users/${userId}/recent-activity`); // Placeholder
+export const fetchAdminRecentFilesAPI = (): Promise<ManagedFile[]> => apiFetch<ManagedFile[]>(`/admin/recent-files`); // Placeholder
 
 // Reports
 export const fetchAllProjectsWithTimeLogsAPI = (): Promise<Project[]> => apiFetch<Project[]>('/reports/projects-with-timelogs');

--- a/components/DashboardOverview.tsx
+++ b/components/DashboardOverview.tsx
@@ -95,7 +95,7 @@ const DashboardOverview: React.FC = () => {
         } else if (user.role === UserRole.FREELANCER) {
           fetchedStats = await fetchFreelancerDashboardStatsAPI(user.id);
         } else if (user.role === UserRole.CLIENT) {
-          fetchedStats = await fetchClientDashboardStatsAPI(user.id);
+          fetchedStats = await fetchClientDashboardStatsAPI();
         }
         setStats(fetchedStats);
 


### PR DESCRIPTION
- I added a new API endpoint `get_client_dashboard_stats` to `backend/api.php`. This endpoint computes and returns statistics for the client role, including total projects, in-progress projects, completed projects, and platform-wide open projects.
- I updated `fetchClientDashboardStatsAPI` in `apiService.ts` to use the new endpoint and the `ClientDashboardStats` type.
- I modified `DashboardOverview.tsx` to correctly call the updated `fetchClientDashboardStatsAPI` and display the fetched statistics for clients.

This should address the issue of updating your client dashboard by populating the overview section with relevant data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new API endpoint for clients to view dashboard statistics, including counts of their projects and open projects platform-wide.
	- Introduced an API endpoint allowing users to send messages within conversations.
- **Improvements**
	- Enhanced the client dashboard to display updated statistics using the new API.
- **Bug Fixes**
	- Improved error handling and validation for dashboard stats and messaging features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->