### PR TITLE
feat: Revamp messaging for multi-freelancer projects and refined work…

### DIFF
--- a/.multicoder/task/database_schema.md
+++ b/.multicoder/task/database_schema.md
@@ -44,9 +44,19 @@ Stores information about projects.
 | `deadline`          | DATE             |                                           | Project deadline                                 |
 | `created_at`        | DATETIME         | NOT NULL, DEFAULT CURRENT_TIMESTAMP       | Timestamp of project creation                    |
 | `updated_at`        | DATETIME         | NOT NULL, DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP | Timestamp of last update                     |
-| `assigned_freelancer_id` | INT         | FOREIGN KEY (`users`.`id`)                | ID of the freelancer assigned to the project (if any) |
+<!-- `assigned_freelancer_id` is removed in favor of `project_assigned_freelancers` junction table -->
 
-### 3. `project_applications`
+### 3. `project_assigned_freelancers` (New Junction Table)
+Links projects to one or more freelancers.
+
+| Column Name     | Data Type        | Constraints                               | Description                                      |
+|-----------------|------------------|-------------------------------------------|--------------------------------------------------|
+| `project_id`    | INT              | NOT NULL, FOREIGN KEY (`projects`.`id`) ON DELETE CASCADE | ID of the project                                |
+| `user_id`       | INT              | NOT NULL, FOREIGN KEY (`users`.`id`) ON DELETE CASCADE    | ID of the freelancer (user with 'freelancer' role) |
+| `role_in_project` | VARCHAR(50)    | NOT NULL, DEFAULT 'member'                | Role of the freelancer in the project (e.g., 'member', 'lead') |
+| PRIMARY KEY (`project_id`, `user_id`) |                                       |                                                   | Ensures a freelancer is only assigned once per project |
+
+### 4. `project_applications`
 Tracks applications made by freelancers for projects.
 
 | Column Name     | Data Type        | Constraints                               | Description                                      |
@@ -59,27 +69,76 @@ Tracks applications made by freelancers for projects.
 | `applied_at`    | DATETIME         | NOT NULL, DEFAULT CURRENT_TIMESTAMP       | Timestamp of application submission              |
 | `updated_at`    | DATETIME         | NOT NULL, DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP | Timestamp of last update                     |
 
-### 4. `messages`
+### 5. `messages`
 Stores messages exchanged between users.
 
 | Column Name     | Data Type        | Constraints                               | Description                                      |
 |-----------------|------------------|-------------------------------------------|--------------------------------------------------|
 | `id`            | INT              | PRIMARY KEY, AUTO_INCREMENT               | Unique identifier for the message                |
 | `sender_id`     | INT              | NOT NULL, FOREIGN KEY (`users`.`id`)      | ID of the message sender                         |
-| `receiver_id`   | INT              | NOT NULL, FOREIGN KEY (`users`.`id`)      | ID of the message receiver                       |
-| `project_id`    | INT              | FOREIGN KEY (`projects`.`id`)             | Optional: ID of the project related to the message |
+| `thread_id`     | INT              | NOT NULL, FOREIGN KEY (`message_threads`.`id`) | ID of the message thread this message belongs to |
 | `content`       | TEXT             | NOT NULL                                  | Message content                                  |
 | `sent_at`       | DATETIME         | NOT NULL, DEFAULT CURRENT_TIMESTAMP       | Timestamp when the message was sent              |
-| `is_read`       | BOOLEAN          | NOT NULL, DEFAULT FALSE                   | Whether the message has been read by the receiver|
+| `attachment_url`| VARCHAR(255)     | NULL                                      | URL to an attached file, if any                  |
+| `attachment_type`| VARCHAR(50)     | NULL                                      | Type of attachment (e.g., 'image/jpeg', 'application/pdf') |
+| `requires_approval` | BOOLEAN      | NOT NULL, DEFAULT FALSE                   | Indicates if this message needs admin approval (e.g. freelancer in project_client_admin_freelancer thread) |
+| `approval_status`   | ENUM('pending', 'approved', 'rejected') | NULL            | Status of the approval, if required              |
+| `approved_by_id`| INT              | FOREIGN KEY (`users`.`id`)                | ID of the admin who actioned the approval        |
+| `approved_at`   | DATETIME         |                                           | Timestamp of approval/rejection action           |
 
-### 5. `job_cards` (or `tasks`)
+
+### 6. `message_threads`
+Groups messages, typically within a project context, defining a specific communication channel.
+
+| Column Name     | Data Type        | Constraints                               | Description                                      |
+|-----------------|------------------|-------------------------------------------|--------------------------------------------------|
+| `id`            | INT              | PRIMARY KEY, AUTO_INCREMENT               | Unique identifier for the message thread         |
+| `project_id`    | INT              | NULL, FOREIGN KEY (`projects`.`id`)       | ID of the project this thread belongs to (NULL for 'direct' type) |
+| `title`         | VARCHAR(255)     |                                           | Optional title for the thread (e.g., "Project X: Client/Admin/Freelancer", or participant names for DMs) |
+| `type`          | ENUM('direct', 'project_admin_freelancer', 'project_admin_client', 'project_client_admin_freelancer') | NOT NULL | Type of communication thread. |
+| `created_by_id` | INT              | NOT NULL, FOREIGN KEY (`users`.`id`)      | User who initiated or created the thread        |
+| `last_message_at`| DATETIME        | NULL                                      | Timestamp of the last message sent in this thread, for sorting/activity. |
+| `created_at`    | DATETIME         | NOT NULL, DEFAULT CURRENT_TIMESTAMP       | Timestamp of thread creation                     |
+| `updated_at`    | DATETIME         | NOT NULL, DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP | Timestamp of last activity/update in thread    |
+| `is_active`     | BOOLEAN          | NOT NULL, DEFAULT TRUE                    | Whether the thread is currently active           |
+| `linked_folder_path` | VARCHAR(1024) | NULL                                   | Path or identifier for the linked project folder for file exchange |
+
+### 7. `thread_participants`
+Links users to message threads and defines their roles or permissions within that thread.
+
+| Column Name       | Data Type        | Constraints                               | Description                                       |
+|-------------------|------------------|-------------------------------------------|---------------------------------------------------|
+| `id`              | INT              | PRIMARY KEY, AUTO_INCREMENT               | Unique identifier for the participant link        |
+| `thread_id`       | INT              | NOT NULL, FOREIGN KEY (`message_threads`.`id`) ON DELETE CASCADE | ID of the message thread                          |
+| `user_id`         | INT              | NOT NULL, FOREIGN KEY (`users`.`id`) ON DELETE CASCADE      | ID of the user participating in the thread      |
+| `role_in_thread`  | ENUM('participant', 'observer') | NOT NULL, DEFAULT 'participant' | User's role (e.g. 'observer' for admin in certain contexts or future use) |
+| `can_message`     | BOOLEAN          | NOT NULL, DEFAULT TRUE                    | Controls if a participant can send messages.      |
+| `visibility_level`| ENUM('all', 'approved_only', 'none') | NOT NULL, DEFAULT 'all' | Controls what messages the user sees (e.g. Client in Type A sees only approved freelancer messages) |
+| `joined_at`       | DATETIME         | NOT NULL, DEFAULT CURRENT_TIMESTAMP       | Timestamp when user joined the thread             |
+| `last_read_message_id` | INT         | FOREIGN KEY (`messages`.`id`) ON DELETE SET NULL | ID of the last message read by this user in this thread |
+| `unread_count`    | INT UNSIGNED     | NOT NULL, DEFAULT 0                       | Count of unread messages for this user in this thread |
+| UNIQUE KEY `thread_user_unique` (`thread_id`, `user_id`) |                   | Ensures a user is only in a thread once       |
+
+### 8. `message_emoticons` (Optional - for emoticon reactions to messages)
+Stores emoticon reactions to messages.
+
+| Column Name     | Data Type        | Constraints                               | Description                                      |
+|-----------------|------------------|-------------------------------------------|--------------------------------------------------|
+| `id`            | INT              | PRIMARY KEY, AUTO_INCREMENT               | Unique identifier for the reaction               |
+| `message_id`    | INT              | NOT NULL, FOREIGN KEY (`messages`.`id`) ON DELETE CASCADE  | ID of the message being reacted to               |
+| `user_id`       | INT              | NOT NULL, FOREIGN KEY (`users`.`id`) ON DELETE CASCADE     | ID of the user who reacted                       |
+| `emoticon_char` | VARCHAR(10)      | NOT NULL                                  | The emoticon character (e.g., "👍", "❤️")         |
+| `created_at`    | DATETIME         | NOT NULL, DEFAULT CURRENT_TIMESTAMP       | Timestamp of when the reaction was added         |
+| UNIQUE KEY `message_user_emoticon` (`message_id`, `user_id`, `emoticon_char`) | | Prevents duplicate reactions by same user on same message with same emoticon |
+
+### 9. `job_cards` (or `tasks`)
 Manages individual tasks or job cards within a project.
 
 | Column Name     | Data Type        | Constraints                               | Description                                      |
 |-----------------|------------------|-------------------------------------------|--------------------------------------------------|
 | `id`            | INT              | PRIMARY KEY, AUTO_INCREMENT               | Unique identifier for the job card/task          |
-| `project_id`    | INT              | NOT NULL, FOREIGN KEY (`projects`.`id`)   | ID of the project this task belongs to           |
-| `assigned_freelancer_id` | INT     | FOREIGN KEY (`users`.`id`)                | ID of the freelancer assigned to this task       |
+| `project_id`    | INT              | NOT NULL, FOREIGN KEY (`projects`.`id`) ON DELETE CASCADE | ID of the project this task belongs to           |
+| `assigned_freelancer_id` | INT     | FOREIGN KEY (`users`.`id`) ON DELETE SET NULL | ID of the freelancer assigned to this task       |
 | `title`         | VARCHAR(255)     | NOT NULL                                  | Task title                                       |
 | `description`   | TEXT             |                                           | Detailed task description                        |
 | `status`        | ENUM('todo', 'in_progress', 'completed', 'archived') | NOT NULL, DEFAULT 'todo' | Current status of the task                     |
@@ -87,27 +146,27 @@ Manages individual tasks or job cards within a project.
 | `created_at`    | DATETIME         | NOT NULL, DEFAULT CURRENT_TIMESTAMP       | Timestamp of task creation                       |
 | `updated_at`    | DATETIME         | NOT NULL, DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP | Timestamp of last update                     |
 
-### 6. `time_logs`
+### 10. `time_logs`
 Records time spent by freelancers on tasks/projects.
 
 | Column Name     | Data Type        | Constraints                               | Description                                      |
 |-----------------|------------------|-------------------------------------------|--------------------------------------------------|
 | `id`            | INT              | PRIMARY KEY, AUTO_INCREMENT               | Unique identifier for the time log               |
-| `job_card_id`   | INT              | NOT NULL, FOREIGN KEY (`job_cards`.`id`)  | ID of the task the time was logged for           |
-| `freelancer_id` | INT              | NOT NULL, FOREIGN KEY (`users`.`id`)      | ID of the freelancer who logged the time         |
+| `job_card_id`   | INT              | NOT NULL, FOREIGN KEY (`job_cards`.`id`) ON DELETE CASCADE | ID of the task the time was logged for           |
+| `freelancer_id` | INT              | NOT NULL, FOREIGN KEY (`users`.`id`) ON DELETE CASCADE    | ID of the freelancer who logged the time         |
 | `start_time`    | DATETIME         | NOT NULL                                  | Start time of the work session                   |
 | `end_time`      | DATETIME         | NOT NULL                                  | End time of the work session                     |
 | `duration_minutes` | INT           | NOT NULL                                  | Duration of work in minutes                      |
 | `notes`         | TEXT             |                                           | Optional notes about the work done               |
 | `logged_at`     | DATETIME         | NOT NULL, DEFAULT CURRENT_TIMESTAMP       | Timestamp when the log was created               |
 
-### 7. `billing_info` (Placeholder - needs more specific requirements)
+### 11. `billing_info` (Placeholder - needs more specific requirements)
 Stores billing related information. This is a basic placeholder.
 
 | Column Name     | Data Type        | Constraints                               | Description                                      |
 |-----------------|------------------|-------------------------------------------|--------------------------------------------------|
 | `id`            | INT              | PRIMARY KEY, AUTO_INCREMENT               | Unique identifier for billing record             |
-| `project_id`    | INT              | NOT NULL, FOREIGN KEY (`projects`.`id`)   | ID of the project being billed                   |
+| `project_id`    | INT              | NOT NULL, FOREIGN KEY (`projects`.`id`) ON DELETE CASCADE | ID of the project being billed                   |
 | `invoice_number`| VARCHAR(50)      | UNIQUE                                    | Invoice number                                   |
 | `amount`        | DECIMAL(10, 2)   | NOT NULL                                  | Amount to be billed                            |
 | `status`        | ENUM('pending', 'paid', 'overdue') | NOT NULL, DEFAULT 'pending' | Billing status                                 |
@@ -116,11 +175,16 @@ Stores billing related information. This is a basic placeholder.
 | `updated_at`    | DATETIME         | NOT NULL, DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP | Timestamp of last update                     |
 
 ## Relationships
-- `users` to `projects`: One (client) to Many (projects). One (freelancer) to Many (assigned projects).
+- `users` to `projects`: One (client) to Many (projects).
+- `projects` to `project_assigned_freelancers`: One (project) to Many (freelancers assigned).
+- `users` to `project_assigned_freelancers`: One (freelancer) to Many (projects assigned to).
 - `users` to `project_applications`: One (freelancer) to Many (applications).
 - `projects` to `project_applications`: One (project) to Many (applications).
-- `users` to `messages`: One (sender) to Many (messages), One (receiver) to Many (messages).
-- `projects` to `messages`: One (project) to Many (messages) (optional link).
+- `message_threads` to `messages`: One (thread) to Many (messages).
+- `users` to `messages`: One (sender) to Many (messages).
+- `message_threads` to `thread_participants`: One (thread) to Many (participants).
+- `users` to `thread_participants`: One (user) to Many (thread participations).
+- `projects` to `message_threads`: One (project) to Many (project-specific threads).
 - `projects` to `job_cards`: One (project) to Many (job_cards/tasks).
 - `users` to `job_cards`: One (freelancer) to Many (assigned job_cards/tasks).
 - `job_cards` to `time_logs`: One (task) to Many (time_logs).

--- a/apiService.ts
+++ b/apiService.ts
@@ -851,106 +851,124 @@ export const deleteFileAPI = (fileId: string): Promise<void> => {
 };
 
 
-// --- Messaging Service Types ---
+// --- ADVANCED MESSAGING SERVICE TYPES ---
 
-export interface ConversationParticipant {
+export interface ThreadParticipant {
   id: number; // User ID
   username: string;
+  avatar_url?: string | null;
 }
 
-// For the list of conversations a user has
-export interface ConversationPreviewPHP {
-  conversation_id: number;
-  created_at: string;    // ISO8601
-  updated_at: string;    // ISO8601
-  last_message_at: string | null; // ISO8601
-  participants: ConversationParticipant[]; // Parsed from backend's GROUP_CONCAT
-  last_message_snippet: string | null;
-  last_message_sender_id: number | null;
-  last_message_sender_username: string | null;
-  unread_message_count: number;
+export interface MessageThread {
+  thread_id: number;
+  project_id?: number | null;
+  project_title?: string | null;
+  title?: string | null; // Custom title for thread or participant names for DMs
+  type: 'direct' | 'project_admin_freelancer' | 'project_admin_client' | 'project_freelancer_client';
+  last_message_at?: string | null; // ISO8601
+  created_at: string; // ISO8601
+  participants: ThreadParticipant[];
+  last_message_snippet?: string | null;
+  last_message_sender_id?: number | null;
+  last_message_sender_username?: string | null;
+  unread_count: number;
 }
 
-// For individual messages within a conversation
-export interface MessagePHP {
-  id: number; // message_id from backend
-  conversation_id: number;
+export interface ThreadMessage {
+  id: number;
+  thread_id: number;
   sender_id: number;
   sender_username: string;
+  sender_avatar_url?: string | null;
   content: string;
-  created_at: string; // ISO8601
-  read_at: string | null; // ISO8601 or null
+  sent_at: string; // ISO8601
+  attachment_url?: string | null;
+  attachment_type?: string | null;
+  requires_approval: boolean;
+  approval_status?: 'pending' | 'approved' | 'rejected' | null;
 }
 
-// Payload for sending a message
-export interface SendMessagePayload {
-  conversation_id: number; // Or string if frontend uses string IDs and converts
+// Payload for sending a message in a thread (project or direct)
+export interface SendThreadMessagePayload {
+  thread_id?: number | null; // Null if creating a new thread with the message
+  project_id?: number | null; // Required if creating a new project-based thread
   content: string;
+  target_user_ids?: number[]; // For creating new 'direct' threads
+  thread_type_hint?: 'direct' | 'project_admin_freelancer' | 'project_admin_client' | 'project_freelancer_client'; // Required if creating new thread
+  admin_client_message_freelancer_visibility?: 'all' | 'non_sensitive_only' | 'none'; // Admin's choice
 }
-// Response for sending a message (is the new message itself)
-export type SendMessageResponse = MessagePHP;
-
-
-// Response for finding/creating a conversation
-export interface FindOrCreateConversationResponse {
-  conversation_id: number;
-  existed: boolean;
-}
-
-// Response for marking conversation as read
-export interface MarkConversationAsReadResponse {
-    message: string;
-    marked_read_count: number;
+export interface SendThreadMessageResponse {
+  message: string;
+  message_id: number;
+  thread_id: number;
+  requires_approval?: boolean;
+  approval_status?: 'pending' | 'approved' | 'rejected' | null;
 }
 
-// --- Messaging Service ---
-// (This will replace/update the existing placeholder messaging functions)
+// Payload for moderating a message
+export interface ModerateMessagePayload {
+  message_id: number;
+  approval_status: 'approved' | 'rejected';
+}
+export interface ModerateMessageResponse {
+  message: string;
+}
 
-export const findOrCreateConversationAPI = (recipientUserId: number | string): Promise<FindOrCreateConversationResponse> => {
-  return apiFetch<FindOrCreateConversationResponse>(`/api.php?action=find_or_create_conversation`, {
-    method: 'POST',
-    body: JSON.stringify({ recipient_user_id: recipientUserId }),
-  }, true); // Requires Auth
-};
 
-export const fetchUserConversationsAPI = (): Promise<ConversationPreviewPHP[]> => {
-  return apiFetch<ConversationPreviewPHP[]>(`/api.php?action=get_user_conversations`, {
+// --- ADVANCED MESSAGING SERVICE ---
+
+export const fetchUserMessageThreadsAPI = (): Promise<MessageThread[]> => {
+  return apiFetch<MessageThread[]>(`/api.php?action=get_user_message_threads`, {
     method: 'GET',
   }, true); // Requires Auth
 };
 
-export interface FetchMessagesParams {
+export interface FetchThreadMessagesParams {
     limit?: number;
-    before_message_id?: number | string; // string if frontend uses string IDs
-    // offset?: number; // If using offset pagination
+    offset?: number; // Or use before_message_id for cursor pagination
 }
-export const fetchConversationMessagesAPI = (conversationId: number | string, params?: FetchMessagesParams): Promise<MessagePHP[]> => {
+export const fetchThreadMessagesAPI = (threadId: number, params?: FetchThreadMessagesParams): Promise<ThreadMessage[]> => {
   const queryParams = new URLSearchParams();
   if (params?.limit) queryParams.append('limit', String(params.limit));
-  if (params?.before_message_id) queryParams.append('before_message_id', String(params.before_message_id));
-  // if (params?.offset) queryParams.append('offset', String(params.offset));
+  if (params?.offset) queryParams.append('offset', String(params.offset));
 
   const queryString = queryParams.toString();
-  const endpoint = `/api.php?action=get_conversation_messages&conversation_id=${conversationId}${queryString ? '&' + queryString : ''}`;
+  const endpoint = `/api.php?action=get_thread_messages&thread_id=${threadId}${queryString ? '&' + queryString : ''}`;
 
-  return apiFetch<MessagePHP[]>(endpoint, {
+  return apiFetch<ThreadMessage[]>(endpoint, {
     method: 'GET',
   }, true); // Requires Auth
 };
 
-export const sendMessageAPI = (payload: SendMessagePayload): Promise<SendMessageResponse> => {
-  return apiFetch<SendMessageResponse>(`/api.php?action=send_message`, {
+// This wraps the versatile 'send_project_message' backend endpoint
+export const sendThreadMessageAPI = (payload: SendThreadMessagePayload): Promise<SendThreadMessageResponse> => {
+  return apiFetch<SendThreadMessageResponse>(`/api.php?action=send_project_message`, {
     method: 'POST',
     body: JSON.stringify(payload),
   }, true); // Requires Auth
 };
 
-export const markConversationAsReadAPI = (conversationId: number | string): Promise<MarkConversationAsReadResponse> => {
-  return apiFetch<MarkConversationAsReadResponse>(`/api.php?action=mark_conversation_as_read`, {
-    method: 'POST', // Or 'PUT' as per backend
-    body: JSON.stringify({ conversation_id: conversationId }),
-  }, true); // Requires Auth
+export const moderateMessageAPI = (payload: ModerateMessagePayload): Promise<ModerateMessageResponse> => {
+  return apiFetch<ModerateMessageResponse>(`/api.php?action=moderate_project_message`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  }, true); // Requires Admin Auth
 };
+
+// The old findOrCreateConversationAPI, fetchUserConversationsAPI, fetchConversationMessagesAPI, sendMessageAPI, markConversationAsReadAPI
+// should be considered deprecated or for a simpler DM-only system if that's still needed separately.
+// For the new project-based and advanced messaging, use the APIs above.
+
+// New API to get users that the current user can message (for DM restrictions)
+// Response type can reuse AdminUserView or a simpler UserContact type
+export interface MessageableUser extends Pick<AdminUserView, 'id' | 'username' | 'email' | 'role' | 'avatar_url'> {}
+
+export const getMessageableUsersAPI = (): Promise<MessageableUser[]> => {
+  return apiFetch<MessageableUser[]>(`/api.php?action=get_messageable_users`, {
+    method: 'GET',
+  }, true); // Requires Auth, backend will filter based on user's role
+};
+
 
 // Comment out or remove old messaging APIs from types.ts if they are fully superseded
 /*

--- a/backend/API_AUTH_DOCS.md
+++ b/backend/API_AUTH_DOCS.md
@@ -1032,7 +1032,175 @@ Endpoints for 1-on-1 user communication.
   {
     "error": "Error message (e.g., Conversation ID required, Forbidden)."
   }
+  ```json
+  {
+    "error": "Error message (e.g., Conversation ID required, Forbidden)."
+  }
   ```
+
+## Advanced Messaging Endpoints (Thread-Based)
+
+These endpoints support more complex, project-related, and permissioned messaging.
+
+### 1. Get Messageable Users (for initiating DMs)
+- **Action**: `get_messageable_users`
+- **Method**: `GET`
+- **URL**: `/backend/api.php?action=get_messageable_users`
+- **Authentication**: **Required**.
+- **Response (Success - 200 OK)**: Array of user objects that the authenticated user is allowed to DM.
+  - If authenticated user is Admin: Returns all (or a relevant subset of) active users.
+  - If authenticated user is Freelancer/Client: Returns only Admin users.
+  ```json
+  [
+    {
+      "id": 1,
+      "username": "admin_user",
+      "email": "admin@example.com",
+      "role": "admin",
+      "avatar_url": "/avatars/admin.png" // Optional
+    }
+    // ... other users if admin is requesting, or only other admins if freelancer/client is requesting
+  ]
+  ```
+
+### 2. Get User's Message Threads
+- **Action**: `get_user_message_threads`
+- **Method**: `GET`
+- **URL**: `/backend/api.php?action=get_user_message_threads`
+- **Authentication**: **Required**.
+- **Response (Success - 200 OK)**: Array of message thread objects.
+  ```json
+  [
+    {
+      "thread_id": 15,
+      "project_id": 123, // Nullable
+      "project_title": "Project Alpha", // Nullable
+      "title": "Project Alpha - Admin/Client Discussion", // Custom or generated title
+      "type": "project_admin_client", // e.g., 'direct', 'project_admin_freelancer', etc.
+      "last_message_at": "YYYY-MM-DD HH:MM:SS",
+      "created_at": "YYYY-MM-DD HH:MM:SS",
+      "participants": [
+        { "id": 1, "username": "admin_user", "avatar_url": null },
+        { "id": 5, "username": "client_user", "avatar_url": "/avatars/client.png" }
+      ],
+      "last_message_snippet": "Yes, that sounds good.",
+      "last_message_sender_id": 5,
+      "last_message_sender_username": "client_user",
+      "unread_count": 0 // Specific to the authenticated user for this thread
+    }
+    // ... more threads. For Type A and Type C project threads, the 'participants' array
+    // will include all freelancers assigned to that project.
+  ]
+  ```
+
+### 3. Get Thread Messages
+- **Action**: `get_thread_messages`
+- **Method**: `GET`
+- **URL**: `/backend/api.php?action=get_thread_messages&thread_id=<id>&limit=50&offset=0`
+  - `thread_id`: Required.
+  - `limit`: Optional, number of messages to fetch (default 50).
+  - `offset`: Optional, for pagination.
+- **Authentication**: **Required** (User must be a participant with appropriate visibility).
+- **Response (Success - 200 OK)**: Array of message objects, respecting user's visibility and message approval status.
+  ```json
+  [
+    {
+      "id": 201,
+      "thread_id": 15,
+      "sender_id": 1,
+      "sender_username": "admin_user",
+      "sender_avatar_url": null,
+      "content": "Please review the attached document.",
+      "sent_at": "YYYY-MM-DD HH:MM:SS",
+      "attachment_url": "/files/doc.pdf", // Nullable
+      "attachment_type": "application/pdf", // Nullable
+      "requires_approval": false,
+      "approval_status": null
+    },
+    {
+      "id": 202,
+      "thread_id": 15,
+      "sender_id": 10, // A freelancer in a project_freelancer_client thread
+      "sender_username": "freelancer_user",
+      "sender_avatar_url": "/avatars/freelancer.png",
+      "content": "Here is the update for the client.",
+      "sent_at": "YYYY-MM-DD HH:MM:SS",
+      "requires_approval": true,
+      "approval_status": "approved" // or "pending", "rejected"
+    }
+  ]
+  ```
+  *(Backend implicitly marks messages as read for the user up to the last fetched message in this thread)*
+
+### 3. Send Project/Thread Message
+- **Action**: `send_project_message`
+- **Method**: `POST`
+- **URL**: `/backend/api.php?action=send_project_message`
+- **Authentication**: **Required**.
+- **Request Body (JSON)**:
+  ```json
+  // To send to an existing thread:
+  {
+    "thread_id": 15,
+    "content": "This is a reply in an existing thread."
+  }
+  // To create a new project-specific thread and send a message:
+  {
+    "project_id": 123,
+    "thread_type_hint": "project_admin_client", // or "project_admin_freelancer", "project_freelancer_client"
+    "content": "Initial message for new project thread.",
+    // Optional for 'project_admin_client' type by admin sender:
+    "admin_client_message_freelancer_visibility": "non_sensitive_only" // "all", "non_sensitive_only", "none"
+  }
+  // To create a new direct message thread and send a message:
+  {
+    "target_user_ids": [456], // Array of recipient user IDs. For F/C senders, backend validates these are Admins.
+    "thread_type_hint": "direct", // Must be 'direct' for this structure
+    "content": "Hello, Admin!" // Optional: Can create an empty thread by omitting content if backend supports. Backend will use project_id from URL for project specific threads.
+  }
+  ```
+- **Response (Success - 201 Created)**:
+  ```json
+  {
+    "message": "Message sent successfully.", // Or "Thread created successfully" if content was empty and only thread was made.
+    "message_id": 205, // Nullable if only thread was created without an initial message.
+    "thread_id": 15, // ID of the thread (either existing or newly created)
+    "requires_approval": false, // True if the message sent requires approval (e.g. freelancer in Type A project_client_admin_freelancer thread)
+    "approval_status": null // 'pending' if requires_approval is true, else null
+  }
+  ```
+- **Response (Error - 4xx/5xx)**:
+  ```json
+  {
+    "error": "Error message (e.g., Thread ID/Project ID/Target IDs required, Content required for message, Forbidden, Invalid thread type, Target users not admins for Freelancer/Client DMs, Project not found for project-specific threads)."
+  }
+  ```
+
+### 4. Moderate Project Message (Admin Action)
+- **Action**: `moderate_project_message`
+- **Method**: `POST`
+- **URL**: `/backend/api.php?action=moderate_project_message`
+- **Authentication**: **Required** (User role must be 'admin').
+- **Request Body (JSON)**:
+  ```json
+  {
+    "message_id": 202,
+    "approval_status": "approved" // or "rejected"
+  }
+  ```
+- **Response (Success - 200 OK)**:
+  ```json
+  {
+    "message": "Message approved successfully." // or "Message rejected successfully."
+  }
+  ```
+- **Response (Error - 4xx/5xx)**:
+  ```json
+  {
+    "error": "Error message (e.g., Message ID and status required, Message not found, Message does not require approval, Forbidden)."
+  }
+  ```
+
 
 ### 4. Send Message
 - **Action**: `send_message`

--- a/backend/api.php
+++ b/backend/api.php
@@ -3259,277 +3259,520 @@ elseif ($action === 'delete_time_log' && ($method === 'DELETE' || $method === 'P
 
 } // END NEW: Delete a Specific Time Log
 
-// NEW: Find or Create 1-on-1 Conversation
-elseif ($action === 'find_or_create_conversation' && $method === 'POST') {
+// --- START NEW ADVANCED MESSAGING API ENDPOINTS ---
+
+// Get all message threads for the authenticated user (can be direct or project-related)
+elseif ($action === 'get_user_message_threads' && $method === 'GET') {
     $authenticated_user = require_authentication($conn);
     $current_user_id = (int)$authenticated_user['id'];
 
-    $data = json_decode(file_get_contents('php://input'), true);
-    $recipient_user_id = isset($data['recipient_user_id']) ? (int)$data['recipient_user_id'] : null;
+    // Fetch threads where the user is a participant
+    // Also fetch participants for each thread to display names, and last message snippet
+    $sql = "SELECT
+                t.id AS thread_id,
+                t.project_id,
+                p_project.title as project_title, -- Added project title
+                t.title AS thread_title,
+                t.type AS thread_type,
+                t.last_message_at,
+                t.created_at AS thread_created_at,
+                GROUP_CONCAT(DISTINCT CONCAT(u.id, ':', u.username, ':', IFNULL(u.avatar_url, '')) SEPARATOR ';') AS participants_data,
+                (SELECT m.content FROM messages m WHERE m.thread_id = t.id ORDER BY m.sent_at DESC LIMIT 1) AS last_message_content,
+                (SELECT m.sender_id FROM messages m WHERE m.thread_id = t.id ORDER BY m.sent_at DESC LIMIT 1) AS last_message_sender_id,
+                (SELECT u_sender.username FROM messages m_sender JOIN users u_sender ON m_sender.sender_id = u_sender.id WHERE m_sender.thread_id = t.id ORDER BY m_sender.sent_at DESC LIMIT 1) AS last_message_sender_username,
+                tp.unread_count,
+                tp.last_read_message_id
+            FROM message_threads t
+            JOIN thread_participants tp ON t.id = tp.thread_id
+            LEFT JOIN projects p_project ON t.project_id = p_project.id -- Left join for project title
+            LEFT JOIN thread_participants tp_all ON t.id = tp_all.thread_id -- To get all participants for the thread
+            LEFT JOIN users u ON tp_all.user_id = u.id
+            WHERE tp.user_id = ? AND t.is_active = 1
+            GROUP BY t.id, p_project.title -- Added project_title to GROUP BY
+            ORDER BY t.last_message_at DESC, t.created_at DESC";
 
-    if (!$recipient_user_id) {
-        send_json_response(400, ['error' => 'Recipient user ID is required.']);
+    $stmt = $conn->prepare($sql);
+    if (!$stmt) {
+        send_json_response(500, ['error' => 'Failed to prepare statement for getting user threads: ' . $conn->error]);
+    }
+    $stmt->bind_param("i", $current_user_id);
+    if (!$stmt->execute()) {
+        send_json_response(500, ['error' => 'Failed to execute statement for getting user threads: ' . $stmt->error]);
     }
 
-    if ($recipient_user_id === $current_user_id) {
-        send_json_response(400, ['error' => 'Cannot create a conversation with yourself.']);
-    }
-
-    // Check if recipient user exists
-    $stmt_user_check = $conn->prepare("SELECT id FROM users WHERE id = ?");
-    if (!$stmt_user_check) { send_json_response(500, ['error' => 'Server error preparing recipient check.']); }
-    $stmt_user_check->bind_param("i", $recipient_user_id);
-    if (!$stmt_user_check->execute()) { send_json_response(500, ['error' => 'Server error executing recipient check.']); }
-    if ($stmt_user_check->get_result()->num_rows === 0) {
-        send_json_response(404, ['error' => 'Recipient user not found.']);
-    }
-    $stmt_user_check->close();
-
-    // Check for existing 1-on-1 conversation
-    // This query finds conversations involving BOTH users, and only those two users.
-    $sql_find_convo = "SELECT cp1.conversation_id
-                       FROM conversation_participants cp1
-                       JOIN conversation_participants cp2 ON cp1.conversation_id = cp2.conversation_id
-                       WHERE cp1.user_id = ? AND cp2.user_id = ?
-                       AND (SELECT COUNT(*) FROM conversation_participants cp_count WHERE cp_count.conversation_id = cp1.conversation_id) = 2";
-
-    $stmt_find = $conn->prepare($sql_find_convo);
-    if (!$stmt_find) { send_json_response(500, ['error' => 'Server error preparing conversation search. ' . $conn->error]); }
-    // Bind params carefully for the two user IDs
-    $stmt_find->bind_param("ii", $current_user_id, $recipient_user_id);
-
-
-    if (!$stmt_find->execute()) { send_json_response(500, ['error' => 'Server error executing conversation search. ' . $stmt_find->error]); }
-    $result_find = $stmt_find->get_result();
-
-    if ($existing_convo = $result_find->fetch_assoc()) {
-        $stmt_find->close();
-        send_json_response(200, ['conversation_id' => (int)$existing_convo['conversation_id'], 'existed' => true]);
-    } else {
-        $stmt_find->close();
-        // No existing 1-on-1 conversation found, create a new one
-        $conn->begin_transaction();
-        try {
-            // 1. Create conversation
-            // last_message_at can be set to NOW() or remain NULL initially
-            $stmt_create_convo = $conn->prepare("INSERT INTO conversations (last_message_at) VALUES (NOW())");
-            if (!$stmt_create_convo) { throw new Exception('Failed to prepare conversation creation. ' . $conn->error); }
-            if (!$stmt_create_convo->execute()) { throw new Exception('Failed to execute conversation creation. ' . $stmt_create_convo->error); }
-            $new_conversation_id = $conn->insert_id;
-            $stmt_create_convo->close();
-
-            if (!$new_conversation_id) { throw new Exception('Failed to get new conversation ID.'); }
-
-            // 2. Add participants
-            $stmt_add_participant = $conn->prepare("INSERT INTO conversation_participants (conversation_id, user_id) VALUES (?, ?)");
-            if (!$stmt_add_participant) { throw new Exception('Failed to prepare participant insertion. ' . $conn->error); }
-
-            // Add current user
-            $stmt_add_participant->bind_param("ii", $new_conversation_id, $current_user_id);
-            if (!$stmt_add_participant->execute()) { throw new Exception('Failed to add current user to conversation. ' . $stmt_add_participant->error); }
-
-            // Add recipient user
-            $stmt_add_participant->bind_param("ii", $new_conversation_id, $recipient_user_id);
-            if (!$stmt_add_participant->execute()) { throw new Exception('Failed to add recipient user to conversation. ' . $stmt_add_participant->error); }
-            $stmt_add_participant->close();
-
-            $conn->commit();
-            send_json_response(201, ['conversation_id' => $new_conversation_id, 'existed' => false]);
-
-        } catch (Exception $e) {
-            $conn->rollback();
-            send_json_response(500, ['error' => 'Failed to create conversation: ' . $e->getMessage()]);
+    $result = $stmt->get_result();
+    $threads_list = [];
+    while ($row = $result->fetch_assoc()) {
+        $participants = [];
+        if ($row['participants_data']) {
+            $participants_raw = explode(';', $row['participants_data']);
+            foreach ($participants_raw as $p_raw) {
+                list($p_id, $p_username, $p_avatar) = explode(':', $p_raw, 3);
+                $participants[] = [
+                    'id' => (int)$p_id,
+                    'username' => $p_username,
+                    'avatar_url' => $p_avatar ?: null // Handle potentially empty avatar part
+                ];
+            }
         }
-    }
-} // END NEW: Find or Create 1-on-1 Conversation
-
-// NEW: Get Messages for a Conversation
-elseif ($action === 'get_conversation_messages' && $method === 'GET') {
-    $authenticated_user = require_authentication($conn);
-    $current_user_id = (int)$authenticated_user['id'];
-
-    $conversation_id = isset($_GET['conversation_id']) ? (int)$_GET['conversation_id'] : null;
-    if (!$conversation_id) {
-        send_json_response(400, ['error' => 'Conversation ID is required.']);
-    }
-
-    // Authorize: Check if current user is part of this conversation
-    $stmt_auth_convo = $conn->prepare(
-        "SELECT c.id AS conversation_exists, cp.user_id AS participant_exists
-         FROM conversations c
-         LEFT JOIN conversation_participants cp ON c.id = cp.conversation_id AND cp.user_id = ?
-         WHERE c.id = ?"
-    );
-    if (!$stmt_auth_convo) { send_json_response(500, ['error' => 'Server error preparing conversation participation check.']); }
-    $stmt_auth_convo->bind_param("ii", $sender_id, $conversation_id);
-    if (!$stmt_auth_convo->execute()) { send_json_response(500, ['error' => 'Server error executing conversation participation check.']); }
-    $result_auth_convo = $stmt_auth_convo->get_result()->fetch_assoc();
-    $stmt_auth_convo->close();
-
-    if (!$result_auth_convo || !$result_auth_convo['conversation_exists']) {
-        send_json_response(404, ['error' => 'Conversation not found.']);
-    }
-    if (!$result_auth_convo['participant_exists']) {
-        send_json_response(403, ['error' => 'Forbidden: You are not a participant in this conversation.']);
-    }
-
-    // Pagination parameters
-    $limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 50;
-    $before_message_id = isset($_GET['before_message_id']) ? (int)$_GET['before_message_id'] : null;
-    $offset = isset($_GET['offset']) ? (int)$_GET['offset'] : 0; // Alternative: offset based pagination
-
-    $sql_messages = "SELECT
-                        m.id AS message_id, m.conversation_id, m.sender_id, m.content,
-                        m.created_at, m.read_at,
-                        u.username AS sender_username
-                     FROM messages m
-                     JOIN users u ON m.sender_id = u.id
-                     WHERE m.conversation_id = ?";
-
-    $params = [$conversation_id];
-    $types = "i";
-
-    if ($before_message_id) {
-        // Assumes IDs are auto-incrementing and somewhat time-ordered for this simple pagination
-        // A more robust cursor pagination would use created_at + id
-        $sql_messages .= " AND m.id < ?";
-        $params[] = $before_message_id;
-        $types .= "i";
-    }
-
-    $sql_messages .= " ORDER BY m.created_at DESC, m.id DESC"; // Get newest first
-    $sql_messages .= " LIMIT ?";
-    $params[] = $limit;
-    $types .= "i";
-
-    // If using offset pagination instead of cursor (before_message_id):
-    // $sql_messages .= " LIMIT ? OFFSET ?";
-    // $params[] = $limit; $params[] = $offset; $types .= "ii";
-
-
-    $stmt_messages = $conn->prepare($sql_messages);
-    if (!$stmt_messages) {
-        send_json_response(500, ['error' => 'Server error preparing message fetch: ' . $conn->error]);
-    }
-    $stmt_messages->bind_param($types, ...$params);
-
-    if (!$stmt_messages->execute()) {
-        send_json_response(500, ['error' => 'Server error executing message fetch: ' . $stmt_messages->error]);
-    }
-    $result_messages = $stmt_messages->get_result();
-
-    $messages_list = [];
-    while ($row = $result_messages->fetch_assoc()) {
-        $messages_list[] = [
-            'id' => (int)$row['message_id'], // message_id aliased as id for frontend typically
-            'conversation_id' => (int)$row['conversation_id'],
-            'sender_id' => (int)$row['sender_id'],
-            'sender_username' => $row['sender_username'],
-            'content' => $row['content'],
-            'created_at' => $row['created_at'], // ISO8601 format from DB
-            'read_at' => $row['read_at'] // ISO8601 format from DB or null
+        $threads_list[] = [
+            'thread_id' => (int)$row['thread_id'],
+            'project_id' => $row['project_id'] ? (int)$row['project_id'] : null,
+            'project_title' => $row['project_title'], // Added project title
+            'title' => $row['thread_title'],
+            'type' => $row['thread_type'],
+            'last_message_at' => $row['last_message_at'],
+            'created_at' => $row['thread_created_at'],
+            'participants' => $participants,
+            'last_message_snippet' => $row['last_message_content'],
+            'last_message_sender_id' => $row['last_message_sender_id'] ? (int)$row['last_message_sender_id'] : null,
+            'last_message_sender_username' => $row['last_message_sender_username'],
+            'unread_count' => (int)$row['unread_count'],
         ];
     }
-    $stmt_messages->close();
+    $stmt->close();
+    send_json_response(200, $threads_list);
+}
 
-    // Messages are fetched newest first, client might want to reverse for display
-    send_json_response(200, array_reverse($messages_list)); // Reverse to get oldest of the batch first for typical chat UI
+// Get messages for a specific thread, respecting permissions
+elseif ($action === 'get_thread_messages' && $method === 'GET') {
+    $authenticated_user = require_authentication($conn);
+    $current_user_id = (int)$authenticated_user['id'];
 
-} // END NEW: Get Messages for a Conversation
+    $thread_id = isset($_GET['thread_id']) ? (int)$_GET['thread_id'] : null;
+    if (!$thread_id) {
+        send_json_response(400, ['error' => 'Thread ID is required.']);
+    }
 
-// NEW: Send Message to a Conversation
-elseif ($action === 'send_message' && $method === 'POST') {
+    // Authorize: Check if current user is a participant of this thread and get their visibility level
+    $stmt_auth = $conn->prepare("SELECT tp.visibility_level, tp.role_in_thread, mt.type as thread_actual_type
+                                 FROM thread_participants tp
+                                 JOIN message_threads mt ON tp.thread_id = mt.id
+                                 WHERE tp.thread_id = ? AND tp.user_id = ?");
+    if (!$stmt_auth) { send_json_response(500, ['error' => 'Auth prep failed: ' . $conn->error]); }
+    $stmt_auth->bind_param("ii", $thread_id, $current_user_id);
+    if (!$stmt_auth->execute()) { send_json_response(500, ['error' => 'Auth exec failed: ' . $stmt_auth->error]); }
+    $result_auth = $stmt_auth->get_result();
+    if ($result_auth->num_rows === 0) {
+        send_json_response(403, ['error' => 'Forbidden: You are not a participant in this thread.']);
+    }
+    $participant_info = $result_auth->fetch_assoc();
+    $visibility_level = $participant_info['visibility_level']; // 'all', 'non_sensitive_only', 'none'
+    $user_role_in_thread = $participant_info['role_in_thread']; // 'participant', 'admin_observer'
+    $thread_actual_type = $participant_info['thread_actual_type'];
+    $stmt_auth->close();
+
+    if ($visibility_level === 'none') {
+        send_json_response(200, []); // User has no visibility, return empty messages
+    }
+
+    $limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 50;
+    $offset = isset($_GET['offset']) ? (int)$_GET['offset'] : 0;
+
+    $sql = "SELECT
+                m.id, m.thread_id, m.sender_id, m.content, m.sent_at,
+                m.attachment_url, m.attachment_type,
+                m.requires_approval, m.approval_status,
+                u.username AS sender_username, u.avatar_url AS sender_avatar_url, u.role as sender_role
+            FROM messages m
+            JOIN users u ON m.sender_id = u.id
+            WHERE m.thread_id = ? ";
+
+    // Visibility and Approval Logic
+    // An admin sees all messages in any thread they are part of, regardless of approval status.
+    // A sender always sees their own messages, even if pending approval.
+    // Others see messages based on approval status and their visibility_level.
+    if ($authenticated_user['role'] !== 'admin' && $current_user_id !== 'm.sender_id') { // This sender_id check needs to be dynamic
+         $sql .= " AND (m.sender_id = {$current_user_id} OR (m.requires_approval = 0) OR (m.requires_approval = 1 AND m.approval_status = 'approved')) ";
+        if ($visibility_level === 'non_sensitive_only') {
+            // This condition might be redundant if approval model covers sensitivity,
+            // or it could mean hiding even approved messages if they are flagged sensitive by other means.
+            // For now, 'non_sensitive_only' for a non-admin means they only see approved messages if they required approval.
+            // This is largely covered by the line above.
+        }
+    }
+
+
+    $sql .= " ORDER BY m.sent_at ASC LIMIT ? OFFSET ?";
+
+    $stmt = $conn->prepare($sql);
+    if (!$stmt) { send_json_response(500, ['error' => 'Msg fetch prep failed: ' . $conn->error]); }
+    $stmt->bind_param("iii", $thread_id, $limit, $offset);
+    if (!$stmt->execute()) { send_json_response(500, ['error' => 'Msg fetch exec failed: ' . $stmt->error]); }
+
+    $result = $stmt->get_result();
+    $messages = [];
+    while ($row = $result->fetch_assoc()) {
+        $can_view_message = false;
+        if ($authenticated_user['role'] === 'admin') {
+            $can_view_message = true;
+        } elseif ((int)$row['sender_id'] === $current_user_id) {
+            $can_view_message = true; // Sender always sees their message
+        } elseif (!(bool)$row['requires_approval'] || $row['approval_status'] === 'approved') {
+            // If message doesn't require approval, or it's approved, check visibility level
+            if ($visibility_level === 'all') {
+                $can_view_message = true;
+            } elseif ($visibility_level === 'non_sensitive_only') {
+                // This assumes that if a message required approval and was approved, it's considered non-sensitive enough
+                // for those with 'non_sensitive_only' visibility.
+                // A more granular system might have an explicit `is_sensitive` flag on messages.
+                $can_view_message = true;
+            }
+        }
+        // If message requires approval and is pending/rejected, non-admin non-sender won't see it.
+
+        if($can_view_message){
+            $messages[] = [
+                'id' => (int)$row['id'],
+                'thread_id' => (int)$row['thread_id'],
+                'sender_id' => (int)$row['sender_id'],
+                'sender_username' => $row['sender_username'],
+                'sender_avatar_url' => $row['sender_avatar_url'],
+                'content' => $row['content'],
+                'sent_at' => $row['sent_at'],
+                'attachment_url' => $row['attachment_url'],
+                'attachment_type' => $row['attachment_type'],
+                'requires_approval' => (bool)$row['requires_approval'],
+                'approval_status' => $row['approval_status'],
+            ];
+        }
+    }
+    $stmt->close();
+
+    if (!empty($messages)) {
+        $last_message_id_fetched = end($messages)['id'];
+        $update_read_stmt = $conn->prepare("UPDATE thread_participants SET last_read_message_id = ?, unread_count = 0 WHERE thread_id = ? AND user_id = ? AND (last_read_message_id < ? OR last_read_message_id IS NULL)");
+        if($update_read_stmt){
+            $update_read_stmt->bind_param("iiii", $last_message_id_fetched, $thread_id, $current_user_id, $last_message_id_fetched);
+            $update_read_stmt->execute();
+            $update_read_stmt->close();
+        } else {
+            error_log("Failed to prepare statement to update read status: " . $conn->error);
+        }
+    }
+    send_json_response(200, $messages);
+}
+
+// Send a message (handles various thread types and permissions)
+elseif ($action === 'send_project_message' && $method === 'POST') {
     $authenticated_user = require_authentication($conn);
     $sender_id = (int)$authenticated_user['id'];
-    $sender_username = $authenticated_user['username']; // For response
+    $sender_role = $authenticated_user['role']; // 'admin', 'client', 'freelancer'
 
     $data = json_decode(file_get_contents('php://input'), true);
-    $conversation_id = isset($data['conversation_id']) ? (int)$data['conversation_id'] : null;
+    $thread_id = isset($data['thread_id']) ? (int)$data['thread_id'] : null;
+    $project_id = isset($data['project_id']) ? (int)$data['project_id'] : null;
     $content = $data['content'] ?? null;
+    $target_user_ids = isset($data['target_user_ids']) && is_array($data['target_user_ids']) ? array_map('intval', $data['target_user_ids']) : []; // For creating new direct/group threads
+    $thread_type_hint = $data['thread_type_hint'] ?? null; // e.g., 'project_admin_client', 'project_admin_freelancer', 'direct'
+    $admin_client_message_freelancer_visibility = isset($data['admin_client_message_freelancer_visibility']) ? $data['admin_client_message_freelancer_visibility'] : 'all'; // 'all', 'non_sensitive_only', 'none'
 
-    if (!$conversation_id || $content === null || trim($content) === '') { // Content can be "0", so check for null or empty string explicitly
-        send_json_response(400, ['error' => 'Conversation ID and message content are required.']);
+
+    if (empty($content)) {
+        send_json_response(400, ['error' => 'Message content is required.']);
+    }
+    if (!$thread_id && !$project_id && empty($target_user_ids)) {
+        send_json_response(400, ['error' => 'Thread ID, Project ID, or Target User IDs must be provided.']);
     }
 
-    $content = trim($content); // Trim content before length check and storage
-    if (mb_strlen($content) > 10000) { // Basic content length validation (e.g. 10k chars)
-        send_json_response(400, ['error' => 'Message content is too long.']);
-    }
-
-    // Start transaction
     $conn->begin_transaction();
-
     try {
-        // 1. Authorization: Check if current user is part of this conversation AND conversation exists
-        $stmt_auth_convo = $conn->prepare(
-            "SELECT c.id AS conversation_exists, cp.user_id AS participant_exists
-             FROM conversations c
-             LEFT JOIN conversation_participants cp ON c.id = cp.conversation_id AND cp.user_id = ?
-             WHERE c.id = ?"
-        );
-        if (!$stmt_auth_convo) { throw new Exception('Server error preparing conversation participation check. ' . $conn->error); }
-        $stmt_auth_convo->bind_param("ii", $sender_id, $conversation_id);
-        if (!$stmt_auth_convo->execute()) { throw new Exception('Server error executing conversation participation check. ' . $stmt_auth_convo->error); }
-        $result_auth_convo = $stmt_auth_convo->get_result()->fetch_assoc();
-        $stmt_auth_convo->close();
+        if (!$thread_id) {
+            // Create a new thread
+            if ($project_id && $thread_type_hint) {
+                // Creating a project-specific thread
+                // Determine participants based on project roles and thread_type_hint
+                $stmt_proj_details = $conn->prepare("SELECT client_id, freelancer_id FROM projects WHERE id = ?");
+                if(!$stmt_proj_details) throw new Exception("DB error: project details prep. ".$conn->error);
+                $stmt_proj_details->bind_param("i", $project_id);
+                $stmt_proj_details->execute();
+                $proj_res = $stmt_proj_details->get_result();
+                if($proj_res->num_rows === 0) throw new Exception("Project not found for new thread.", 404);
+                $project_data = $proj_res->fetch_assoc();
+                $stmt_proj_details->close();
 
-        if (!$result_auth_convo || !$result_auth_convo['conversation_exists']) {
-            throw new Exception('Conversation not found.', 404);
-        }
-        if (!$result_auth_convo['participant_exists']) {
-            throw new Exception('Forbidden: You are not a participant in this conversation.', 403);
+                $project_client_id = (int)$project_data['client_id'];
+                $project_freelancer_id = $project_data['freelancer_id'] ? (int)$project_data['freelancer_id'] : null;
+
+                $thread_participants_to_add = [];
+                $thread_title_parts = [];
+
+                if ($thread_type_hint === 'project_admin_client') {
+                    if ($sender_id !== $project_client_id && $sender_role !== 'admin') throw new Exception("Forbidden to create admin-client thread.", 403);
+                    $thread_participants_to_add[$sender_id] = ['role_in_thread' => 'participant', 'visibility_level' => 'all', 'can_message_directly' => true];
+                    if ($sender_id !== $project_client_id) $thread_participants_to_add[$project_client_id] = ['role_in_thread' => 'participant', 'visibility_level' => 'all', 'can_message_directly' => true];
+                    // Admin is always a participant or observer
+                     if (!isset($thread_participants_to_add[$sender_id]) && $sender_role === 'admin') $thread_participants_to_add[$sender_id] = ['role_in_thread' => 'participant', 'visibility_level' => 'all', 'can_message_directly' => true];
+
+                    // Add freelancer as observer if project has one and admin chooses visibility
+                    if($project_freelancer_id && $admin_client_message_freelancer_visibility !== 'none'){
+                         $thread_participants_to_add[$project_freelancer_id] = ['role_in_thread' => 'admin_observer', 'visibility_level' => $admin_client_message_freelancer_visibility, 'can_message_directly' => false];
+                    }
+                    $thread_title_parts[] = "Project Client";
+
+                } elseif ($thread_type_hint === 'project_admin_freelancer') {
+                     if (!$project_freelancer_id) throw new Exception("Project has no assigned freelancer for this thread type.", 400);
+                     if ($sender_id !== $project_freelancer_id && $sender_role !== 'admin') throw new Exception("Forbidden to create admin-freelancer thread.", 403);
+                     $thread_participants_to_add[$sender_id] = ['role_in_thread' => 'participant', 'visibility_level' => 'all', 'can_message_directly' => true];
+                     if ($sender_id !== $project_freelancer_id) $thread_participants_to_add[$project_freelancer_id] = ['role_in_thread' => 'participant', 'visibility_level' => 'all', 'can_message_directly' => true];
+                     if (!isset($thread_participants_to_add[$sender_id]) && $sender_role === 'admin') $thread_participants_to_add[$sender_id] = ['role_in_thread' => 'participant', 'visibility_level' => 'all', 'can_message_directly' => true];
+                     $thread_title_parts[] = "Project Freelancer";
+
+                } elseif ($thread_type_hint === 'project_freelancer_client') {
+                    if (!$project_freelancer_id) throw new Exception("Project has no assigned freelancer for this thread type.", 400);
+                    if (($sender_id !== $project_client_id) && ($sender_id !== $project_freelancer_id)) throw new Exception("Forbidden to create freelancer-client thread.", 403);
+                    $thread_participants_to_add[$project_client_id] = ['role_in_thread' => 'participant', 'visibility_level' => 'all', 'can_message_directly' => true];
+                    $thread_participants_to_add[$project_freelancer_id] = ['role_in_thread' => 'participant', 'visibility_level' => 'all', 'can_message_directly' => true];
+                    // Admin as observer
+                    // Find an admin to add as observer - for simplicity, can be the sender if admin, or first active admin.
+                    // This part needs careful selection of which admin if multiple.
+                    $thread_participants_to_add[$sender_id] = ['role_in_thread' => 'participant', 'visibility_level' => 'all', 'can_message_directly' => true]; // ensure sender is there
+                    // Add an admin as observer. For now, if sender is not admin, pick first active admin.
+                    if($sender_role !== 'admin'){
+                        $admin_observer_stmt = $conn->prepare("SELECT id FROM users WHERE role='admin' AND is_active=1 LIMIT 1");
+                        $admin_observer_stmt->execute();
+                        $admin_obs_res = $admin_observer_stmt->get_result();
+                        if($admin_obs_data = $admin_obs_res->fetch_assoc()){
+                            $thread_participants_to_add[(int)$admin_obs_data['id']] = ['role_in_thread' => 'admin_observer', 'visibility_level' => 'all', 'can_message_directly' => false];
+                        }
+                        $admin_observer_stmt->close();
+                    }
+                     $thread_title_parts[] = "Freelancer/Client";
+                } else {
+                    throw new Exception("Invalid project thread type hint.", 400);
+                }
+
+                $final_thread_title = "Project {$project_id}: " . implode(" & ", $thread_title_parts);
+                $stmt_create_thread = $conn->prepare("INSERT INTO message_threads (project_id, title, type, created_by_id, last_message_at) VALUES (?, ?, ?, ?, NOW())");
+                if(!$stmt_create_thread) throw new Exception("DB error: create thread prep. ".$conn->error);
+                $stmt_create_thread->bind_param("issi", $project_id, $final_thread_title, $thread_type_hint, $sender_id);
+                if(!$stmt_create_thread->execute()) throw new Exception("DB error: create thread exec. ".$stmt_create_thread->error);
+                $thread_id = $conn->insert_id;
+                $stmt_create_thread->close();
+
+                $stmt_add_p = $conn->prepare("INSERT INTO thread_participants (thread_id, user_id, role_in_thread, visibility_level, can_message_directly) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE role_in_thread=VALUES(role_in_thread), visibility_level=VALUES(visibility_level), can_message_directly=VALUES(can_message_directly)");
+                if(!$stmt_add_p) throw new Exception("DB error: add participant prep. ".$conn->error);
+                foreach($thread_participants_to_add as $user_id_to_add => $p_data){
+                    $stmt_add_p->bind_param("iisss", $thread_id, $user_id_to_add, $p_data['role_in_thread'], $p_data['visibility_level'], $p_data['can_message_directly']);
+                    if(!$stmt_add_p->execute())  throw new Exception("DB error: add participant exec for user $user_id_to_add. ".$stmt_add_p->error);
+                }
+                $stmt_add_p->close();
+
+            } elseif (!empty($target_user_ids) && $thread_type_hint === 'direct') {
+                // Creating a direct message (1-on-1 or small group)
+                if (count($target_user_ids) === 1 && $target_user_ids[0] === $sender_id) throw new Exception("Cannot create a direct message thread with only yourself.", 400);
+                $all_participants_for_dm = array_unique(array_merge($target_user_ids, [$sender_id]));
+                sort($all_participants_for_dm); // Sort to create a consistent title/identifier if needed
+
+                // Check if a similar DM thread already exists (same participants, type 'direct')
+                 $sql_find_dm = "SELECT t.id
+                                FROM message_threads t
+                                WHERE t.type = 'direct' AND
+                                      (SELECT COUNT(DISTINCT tp.user_id) FROM thread_participants tp WHERE tp.thread_id = t.id) = ? AND
+                                      NOT EXISTS (
+                                        SELECT u_id FROM (SELECT ? AS u_id ".str_repeat("UNION ALL SELECT ?", count($all_participants_for_dm)-1).") AS expected_users
+                                        WHERE u_id NOT IN (SELECT tp_check.user_id FROM thread_participants tp_check WHERE tp_check.thread_id = t.id)
+                                      ) AND
+                                       NOT EXISTS (
+                                        SELECT tp_check.user_id FROM thread_participants tp_check WHERE tp_check.thread_id = t.id
+                                        AND tp_check.user_id NOT IN (".implode(',', array_fill(0, count($all_participants_for_dm), '?')).")
+                                      )
+                                LIMIT 1";
+
+                $find_params = array_merge([count($all_participants_for_dm)], $all_participants_for_dm, $all_participants_for_dm);
+                $find_types = "i" . str_repeat('i', count($all_participants_for_dm) * 2);
+
+                $stmt_find_dm_thread = $conn->prepare($sql_find_dm);
+                 if (!$stmt_find_dm_thread) throw new Exception("DB error: find DM prep. " . $conn->error);
+                $stmt_find_dm_thread->bind_param($find_types, ...$find_params);
+                $stmt_find_dm_thread->execute();
+                $res_find_dm = $stmt_find_dm_thread->get_result();
+                if($existing_dm = $res_find_dm->fetch_assoc()){
+                    $thread_id = (int)$existing_dm['id'];
+                } else {
+                    // Create new direct thread
+                    $dm_title_users = []; // Fetch usernames for title
+                    $stmt_get_usernames = $conn->prepare("SELECT username FROM users WHERE id = ?");
+                    foreach($all_participants_for_dm as $uid) {
+                        $stmt_get_usernames->bind_param("i", $uid); $stmt_get_usernames->execute();
+                        $dm_title_users[] = $stmt_get_usernames->get_result()->fetch_assoc()['username'];
+                    }
+                    $stmt_get_usernames->close();
+                    $dm_thread_title = implode(', ', $dm_title_users);
+
+                    $stmt_create_thread = $conn->prepare("INSERT INTO message_threads (title, type, created_by_id, last_message_at) VALUES (?, 'direct', ?, NOW())");
+                    if(!$stmt_create_thread) throw new Exception("DB error: create DM thread prep. ".$conn->error);
+                    $stmt_create_thread->bind_param("si", $dm_thread_title, $sender_id);
+                    if(!$stmt_create_thread->execute()) throw new Exception("DB error: create DM thread exec. ".$stmt_create_thread->error);
+                    $thread_id = $conn->insert_id;
+                    $stmt_create_thread->close();
+
+                    $stmt_add_p = $conn->prepare("INSERT INTO thread_participants (thread_id, user_id, role_in_thread, visibility_level, can_message_directly) VALUES (?, ?, 'participant', 'all', 1)");
+                    if(!$stmt_add_p) throw new Exception("DB error: add DM participant prep. ".$conn->error);
+                    foreach($all_participants_for_dm as $user_id_to_add){
+                        $stmt_add_p->bind_param("ii", $thread_id, $user_id_to_add);
+                        if(!$stmt_add_p->execute())  throw new Exception("DB error: add DM participant exec for $user_id_to_add. ".$stmt_add_p->error);
+                    }
+                    $stmt_add_p->close();
+                }
+                $stmt_find_dm_thread->close();
+            } else {
+                 throw new Exception("Insufficient data to determine or create a thread.");
+            }
         }
 
-        // 2. Insert the new message
-        $current_timestamp_mysql = date('Y-m-d H:i:s'); // For consistent timestamp
+        // Authorization: Check if sender is a participant of the thread and can send messages
+        $stmt_auth_participant = $conn->prepare("SELECT tp.can_message_directly, mt.type as current_thread_type, mt.project_id as current_project_id
+                                                 FROM thread_participants tp
+                                                 JOIN message_threads mt ON tp.thread_id = mt.id
+                                                 WHERE tp.thread_id = ? AND tp.user_id = ?");
+        if (!$stmt_auth_participant) throw new Exception("Auth participant prep failed: " . $conn->error);
+        $stmt_auth_participant->bind_param("ii", $thread_id, $sender_id);
+        if (!$stmt_auth_participant->execute()) throw new Exception("Auth participant exec failed: " . $stmt_auth_participant->error);
+        $result_auth_participant = $stmt_auth_participant->get_result();
+        if ($result_auth_participant->num_rows === 0) {
+            throw new Exception("Forbidden: You are not a participant in this thread or thread does not exist.", 403);
+        }
+        $participant_details = $result_auth_participant->fetch_assoc();
+        if (!$participant_details['can_message_directly']) {
+            throw new Exception("Forbidden: You do not have permission to send messages in this thread.", 403);
+        }
+        $current_thread_type = $participant_details['current_thread_type'];
+        // $current_project_id = $participant_details['current_project_id']; // Already have $project_id if creating new
+        $stmt_auth_participant->close();
+
+        $requires_approval = false;
+        $approval_status = null; // Default for messages not requiring approval
+
+        if ($sender_role === 'freelancer' && $current_thread_type === 'project_freelancer_client') {
+            $requires_approval = true;
+            $approval_status = 'pending';
+        }
+
+        $current_timestamp_mysql = date('Y-m-d H:i:s');
         $stmt_insert_message = $conn->prepare(
-            "INSERT INTO messages (conversation_id, sender_id, content, created_at)
-             VALUES (?, ?, ?, ?)"
+            "INSERT INTO messages (thread_id, sender_id, content, sent_at, requires_approval, approval_status)
+             VALUES (?, ?, ?, ?, ?, ?)"
         );
-        if (!$stmt_insert_message) { throw new Exception('Server error preparing message insertion. ' . $conn->error); }
-        $stmt_insert_message->bind_param("iiss", $conversation_id, $sender_id, $content, $current_timestamp_mysql);
-        if (!$stmt_insert_message->execute()) { throw new Exception('Server error executing message insertion. ' . $stmt_insert_message->error); }
+        if (!$stmt_insert_message) throw new Exception("Msg insert prep failed: " . $conn->error);
+        $stmt_insert_message->bind_param("iissis", $thread_id, $sender_id, $content, $current_timestamp_mysql, $requires_approval, $approval_status);
+        if (!$stmt_insert_message->execute()) throw new Exception("Msg insert exec failed: " . $stmt_insert_message->error . " Thread: $thread_id, Sender: $sender_id");
         $new_message_id = $conn->insert_id;
         $stmt_insert_message->close();
 
-        if (!$new_message_id) {
-            throw new Exception('Failed to create message or get new message ID.');
+        $stmt_update_thread = $conn->prepare("UPDATE message_threads SET last_message_at = ? WHERE id = ?");
+        if (!$stmt_update_thread) throw new Exception("Thread update prep failed: " . $conn->error);
+        $stmt_update_thread->bind_param("si", $current_timestamp_mysql, $thread_id);
+        $stmt_update_thread->execute();
+        $stmt_update_thread->close();
+
+        $stmt_update_unread = $conn->prepare("UPDATE thread_participants SET unread_count = unread_count + 1 WHERE thread_id = ? AND user_id != ?");
+        if ($stmt_update_unread) {
+            $stmt_update_unread->bind_param("ii", $thread_id, $sender_id);
+            $stmt_update_unread->execute();
+            $stmt_update_unread->close();
+        } else { error_log("Unread update prep failed: " . $conn->error); }
+
+        // Handle admin sending to client and freelancer visibility adjustment
+        if ($sender_role === 'admin' && $current_thread_type === 'project_admin_client' && $project_id) {
+            $stmt_get_proj_freelancer = $conn->prepare("SELECT freelancer_id FROM projects WHERE id = ?");
+            if($stmt_get_proj_freelancer){
+                $stmt_get_proj_freelancer->bind_param("i", $project_id); // Use $project_id from input or fetched if thread existed
+                $stmt_get_proj_freelancer->execute();
+                $res_proj_freelancer = $stmt_get_proj_freelancer->get_result();
+                if($proj_f_data = $res_proj_freelancer->fetch_assoc()){
+                    $project_freelancer_id_for_visibility = $proj_f_data['freelancer_id'] ? (int)$proj_f_data['freelancer_id'] : null;
+                    if($project_freelancer_id_for_visibility){
+                        $stmt_update_f_visibility = $conn->prepare("UPDATE thread_participants SET visibility_level = ? WHERE thread_id = ? AND user_id = ? AND role_in_thread = 'admin_observer'");
+                        if($stmt_update_f_visibility){
+                            $stmt_update_f_visibility->bind_param("sii", $admin_client_message_freelancer_visibility, $thread_id, $project_freelancer_id_for_visibility);
+                            $stmt_update_f_visibility->execute();
+                            $stmt_update_f_visibility->close();
+                        } else { error_log("Update freelancer visibility prep failed: ".$conn->error); }
+                    }
+                }
+                $stmt_get_proj_freelancer->close();
+            } else { error_log("Get project freelancer prep failed: ".$conn->error); }
         }
 
-        // 3. Update last_message_at in conversations table
-        $stmt_update_convo = $conn->prepare("UPDATE conversations SET last_message_at = ? WHERE id = ?");
-        if (!$stmt_update_convo) { throw new Exception('Server error preparing conversation update. ' . $conn->error); }
-        $stmt_update_convo->bind_param("si", $current_timestamp_mysql, $conversation_id);
-        if (!$stmt_update_convo->execute()) { throw new Exception('Server error executing conversation update. ' . $stmt_update_convo->error); }
-        $stmt_update_convo->close();
-
-        // Commit transaction
         $conn->commit();
-
-        // Prepare and send response
-        $new_message_data = [
-            'id' => $new_message_id,
-            'conversation_id' => $conversation_id,
-            'sender_id' => $sender_id,
-            'sender_username' => $sender_username, // Added for immediate use by frontend
-            'content' => $content,
-            'created_at' => $current_timestamp_mysql,
-            'read_at' => null // New messages are unread by default for others
-        ];
-        send_json_response(201, $new_message_data);
+        send_json_response(201, [
+            'message' => 'Message sent successfully.', 'message_id' => $new_message_id, 'thread_id' => $thread_id,
+            'requires_approval' => $requires_approval, 'approval_status' => $approval_status
+        ]);
 
     } catch (Exception $e) {
         $conn->rollback();
-        $error_code = $e->getCode() >= 400 && $e->getCode() < 500 ? $e->getCode() : 500; // Use specific client error codes if set
-        if ($error_code === 403) {
-            send_json_response(403, ['error' => $e->getMessage()]);
-        } elseif ($error_code === 404) {
-            send_json_response(404, ['error' => $e->getMessage()]);
-        } else {
-            send_json_response($error_code, ['error' => 'Failed to send message: ' . $e->getMessage()]);
-        }
+        $error_code = $e->getCode() === 403 || $e->getCode() === 404 || $e->getCode() === 400 ? $e->getCode() : 500;
+        send_json_response($error_code, ['error' => "Send message failed: " . $e->getMessage()]);
     }
-} // END NEW: Send Message to a Conversation
+}
+
+
+// Admin approves or rejects a message
+elseif ($action === 'moderate_project_message' && $method === 'POST') {
+    $authenticated_user = require_authentication($conn);
+    if ($authenticated_user['role'] !== 'admin') {
+        send_json_response(403, ['error' => 'Forbidden: Only admins can moderate messages.']);
+    }
+    $admin_id = (int)$authenticated_user['id'];
+
+    $data = json_decode(file_get_contents('php://input'), true);
+    $message_id = isset($data['message_id']) ? (int)$data['message_id'] : null;
+    $new_approval_status = $data['approval_status'] ?? null; // 'approved' or 'rejected'
+
+    if (!$message_id || !in_array($new_approval_status, ['approved', 'rejected'])) {
+        send_json_response(400, ['error' => 'Message ID and valid approval status (approved/rejected) are required.']);
+    }
+
+    $stmt_check_msg = $conn->prepare("SELECT requires_approval, approval_status, thread_id, sender_id FROM messages WHERE id = ?");
+    if(!$stmt_check_msg) { send_json_response(500, ['error' => 'DB error checking message: ' . $conn->error]); }
+    $stmt_check_msg->bind_param("i", $message_id);
+    $stmt_check_msg->execute();
+    $result_msg_check = $stmt_check_msg->get_result();
+    if($result_msg_check->num_rows === 0) {
+        send_json_response(404, ['error' => 'Message not found.']);
+    }
+    $msg_data = $result_msg_check->fetch_assoc();
+    $message_thread_id = (int)$msg_data['thread_id'];
+    // $message_sender_id = (int)$msg_data['sender_id'];
+
+    if(!$msg_data['requires_approval']) {
+        send_json_response(400, ['error' => 'This message does not require approval.']);
+    }
+    $stmt_check_msg->close();
+
+    $stmt_update = $conn->prepare("UPDATE messages SET approval_status = ?, approved_by_id = ?, approved_at = NOW() WHERE id = ? AND requires_approval = 1");
+    if (!$stmt_update) {
+        send_json_response(500, ['error' => 'Failed to prepare message moderation statement: ' . $conn->error]);
+    }
+    $stmt_update->bind_param("sii", $new_approval_status, $admin_id, $message_id);
+
+    if ($stmt_update->execute()) {
+        if ($stmt_update->affected_rows > 0) {
+            if ($new_approval_status === 'approved') {
+                // If approved, increment unread count for participants of this thread (except sender and admin who just approved)
+                // This requires knowing the thread_id and who the participants are.
+                $stmt_notify_participants = $conn->prepare("UPDATE thread_participants SET unread_count = unread_count + 1 WHERE thread_id = ? AND user_id != ? AND user_id != ?");
+                if($stmt_notify_participants){
+                    $stmt_notify_participants->bind_param("iii", $message_thread_id, $msg_data['sender_id'], $admin_id);
+                    $stmt_notify_participants->execute();
+                    $stmt_notify_participants->close();
+                } else {
+                    error_log("Failed to prepare unread increment on approval: " . $conn->error);
+                }
+            }
+            send_json_response(200, ['message' => "Message {$new_approval_status} successfully."]);
+        } else {
+            send_json_response(400, ['message' => 'Message not updated. It might not require approval, not found, or status already set.']);
+        }
+    } else {
+        send_json_response(500, ['error' => 'Failed to moderate message: ' . $stmt_update->error]);
+    }
+    $stmt_update->close();
+}
+
+// --- END NEW ADVANCED MESSAGING API ENDPOINTS ---
 
 // --- Projects API ---
 // MODIFIED: get_projects to handle single project fetch and join user tables

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -10,6 +10,7 @@ import Sidebar, { SidebarNavItem } from './shared/Sidebar';
 import DashboardOverview from './DashboardOverview'; 
 import UserManagement from './admin/UserManagement';
 import ProjectManagement from './admin/ProjectManagement';
+import AdminProjectMessagingPage from './admin/AdminProjectMessagingPage'; // Import the new Admin Messaging Page
 import AdminBillingPlaceholder from './admin/AdminBillingPlaceholder'; 
 import AdminTimeLogReportPage from './admin/AdminTimeLogReportPage'; 
 import ProjectBrowser from './freelancer/ProjectBrowser';
@@ -32,6 +33,7 @@ const getSidebarNavItems = (role: UserRole): SidebarNavItem[] => {
         { label: 'Overview', to: NAV_LINKS.DASHBOARD_OVERVIEW, icon: <HomeIcon /> },
         { label: 'User Management', to: `${baseDashboardPath}/${NAV_LINKS.ADMIN_USERS}`, icon: <UsersIcon /> },
         { label: 'Projects', to: `${baseDashboardPath}/${NAV_LINKS.ADMIN_PROJECTS}`, icon: <BriefcaseIcon /> },
+        { label: 'Project Messaging', to: `${baseDashboardPath}/${NAV_LINKS.ADMIN_PROJECT_MESSAGING}`, icon: <ChatBubbleLeftRightIcon /> }, // New Link for Admin
         // Create Project link removed as it's handled via modal in ProjectManagement
         // { label: 'New Project', to: `${baseDashboardPath}/${NAV_LINKS.ADMIN_CREATE_PROJECT}`, icon: <PlusCircleIcon /> },
         { label: 'Billing', to: `${baseDashboardPath}/${NAV_LINKS.ADMIN_BILLING}`, icon: <CurrencyDollarIcon /> },
@@ -97,6 +99,7 @@ const Dashboard: React.FC = () => {
             <>
               <Route path={NAV_LINKS.ADMIN_USERS} element={<UserManagement />} />
               <Route path={NAV_LINKS.ADMIN_PROJECTS} element={<ProjectManagement />} />
+              <Route path={NAV_LINKS.ADMIN_PROJECT_MESSAGING} element={<AdminProjectMessagingPage />} /> {/* New Route for Admin */}
               {/* ADMIN_CREATE_PROJECT route logic is now handled within ProjectManagement via modal */}
               {/* <Route path={NAV_LINKS.ADMIN_CREATE_PROJECT} element={<ProjectManagement />} />  */}
               <Route path={NAV_LINKS.ADMIN_BILLING} element={<AdminBillingPlaceholder />} />

--- a/components/MessagingPage.tsx
+++ b/components/MessagingPage.tsx
@@ -1,44 +1,37 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
-import { useAuth } from "../contexts/AuthContext";
+import { useAuth } from "../contexts/AuthContext"; // Path adjusted
 import {
-  ConversationResponse,
-  MessageResponse,
-  SendMessagePayload,
-  findOrCreateConversationAPI,
-  sendMessageAPI
-} from "../apiService";
+  MessageThread,
+  ThreadMessage,
+  SendThreadMessagePayload,
+  fetchUserMessageThreadsAPI,
+  fetchThreadMessagesAPI,
+  sendThreadMessageAPI,
+  // For "New Chat" modal to find users
+  getMessageableUsersAPI, // Use the new API for DM restrictions
+  MessageableUser as UserToChatWith, // Use the new type
+} from "../apiService"; // Path adjusted
 import { useNavigate, useLocation } from "react-router-dom";
-import Button from "./shared/Button";
+import Button from "./shared/Button"; // Path adjusted
 import {
   PaperAirplaneIcon,
   ArrowLeftIcon,
   ChatBubbleLeftRightIcon,
-  UsersIcon
-} from "./shared/IconComponents";
-import LoadingSpinner from "./shared/LoadingSpinner";
+  UsersIcon,
+  ClockIcon, // For pending status
+  CheckCircleIcon, // For approved status
+  XCircleIcon, // For rejected status
+} from "./shared/IconComponents"; // Path adjusted
+import LoadingSpinner from "./shared/LoadingSpinner"; // Path adjusted
+import Modal from "./shared/Modal"; // Path adjusted
 
-interface AdminUserView {
-  id: string;
-  username: string;
-  email: string;
-  role: string;
-}
 
-interface Conversation extends ConversationResponse {
-  participants: {
-    id: string;
-    username: string;
-    avatarUrl?: string;
-  }[];
-  last_message?: {
-    content: string;
-    timestamp: string;
-    sender_id: string;
-  };
-  unread_count: number;
-}
+// AdminUserView was for admin user management, renaming for clarity for "new chat user list"
+// Using UserToChatWith (imported as AdminUserView and aliased)
 
-const formatMessageTimestamp = (isoString: string | null): string => {
+// Conversation interface is replaced by MessageThread from apiService.ts
+
+const formatMessageTimestamp = (isoString: string | null | undefined): string => {
   if (!isoString) return '';
   const date = new Date(isoString);
   return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
@@ -46,23 +39,22 @@ const formatMessageTimestamp = (isoString: string | null): string => {
 
 const MessagingPage: React.FC = () => {
   const { user } = useAuth();
-  const navigate = useNavigate();
-  const location = useLocation();
+  // const navigate = useNavigate(); // Not currently used
+  // const location = useLocation(); // Not currently used
 
-  const [conversations, setConversations] = useState<Conversation[]>([]);
-  const [selectedConversation, setSelectedConversation] = useState<Conversation | null>(null);
-  const [messages, setMessages] = useState<MessageResponse[]>([]);
+  const [threads, setThreads] = useState<MessageThread[]>([]);
+  const [selectedThread, setSelectedThread] = useState<MessageThread | null>(null);
+  const [messages, setMessages] = useState<ThreadMessage[]>([]); // Updated type
   const [newMessageContent, setNewMessageContent] = useState('');
-  const [isLoadingConversations, setIsLoadingConversations] = useState(true);
+  const [isLoadingThreads, setIsLoadingThreads] = useState(true);
   const [isLoadingMessages, setIsLoadingMessages] = useState(false);
   const [isSendingMessage, setIsSendingMessage] = useState(false);
-  // const [isAttachFileModalOpen, setIsAttachFileModalOpen] = useState(false); // File uploads deferred
   const [error, setError] = useState<string | null>(null);
 
-  const [isCreateConversationModalOpen, setIsCreateConversationModalOpen] = useState(false);
-  const [usersForNewConversation, setUsersForNewConversation] = useState<AdminUserView[]>([]);
-  const [searchTermForNewConversation, setSearchTermForNewConversation] = useState('');
-  const [isCreatingConversation, setIsCreatingConversation] = useState(false);
+  const [isCreateChatModalOpen, setIsCreateChatModalOpen] = useState(false);
+  const [usersForNewChat, setUsersForNewChat] = useState<UserToChatWith[]>([]); // Updated type
+  const [searchTermForNewChat, setSearchTermForNewChat] = useState('');
+  const [isCreatingChat, setIsCreatingChat] = useState(false);
 
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -73,58 +65,50 @@ const MessagingPage: React.FC = () => {
 
   useEffect(scrollToBottom, [messages]);
 
-  const loadConversations = useCallback(async (selectConvId?: number) => {
+  const loadThreads = useCallback(async (selectThreadId?: number) => {
     if (!user) return;
-    setIsLoadingConversations(true); setError(null);
+    setIsLoadingThreads(true); setError(null);
     try {
-      const userConversations = await fetchUserConversationsAPI();
-      userConversations.sort((a, b) => {
-          if (a.last_message_at === null && b.last_message_at === null) return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
-          if (a.last_message_at === null) return 1;
-          if (b.last_message_at === null) return -1;
-          return new Date(b.last_message_at).getTime() - new Date(a.last_message_at).getTime();
+      const userThreads = await fetchUserMessageThreadsAPI();
+      // Sorting logic can remain similar if last_message_at and created_at are available
+      userThreads.sort((a, b) => {
+        const aTimestamp = a.last_message_at ? new Date(a.last_message_at).getTime() : new Date(a.created_at).getTime();
+        const bTimestamp = b.last_message_at ? new Date(b.last_message_at).getTime() : new Date(b.created_at).getTime();
+        return bTimestamp - aTimestamp;
       });
-      setConversations(userConversations);
-      if (selectConvId) {
-        const toSelect = userConversations.find(c => c.conversation_id === selectConvId);
-        if (toSelect) setSelectedConversation(toSelect);
-      } else if (userConversations.length > 0 && !selectedConversation) {
-        // Optionally select the first conversation if none is selected
-        // setSelectedConversation(userConversations[0]);
+      setThreads(userThreads);
+      if (selectThreadId) {
+        const toSelect = userThreads.find(t => t.thread_id === selectThreadId);
+        if (toSelect) setSelectedThread(toSelect);
+      } else if (userThreads.length > 0 && !selectedThread) {
+        // setSelectedThread(userThreads[0]); // Optionally auto-select first thread
       }
-    } catch (err:any) {
-      console.error("Failed to load conversations:", err);
-      setError(err.message || "Could not load chats. Please try again.");
+    } catch (err: any) {
+      console.error("Failed to load threads:", err);
+      setError(err.message || "Could not load your chats. Please try again.");
     } finally {
-      setIsLoadingConversations(false);
+      setIsLoadingThreads(false);
     }
-  }, [user, selectedConversation]); // Added selectedConversation to deps to potentially auto-select first if current is null
+  }, [user, selectedThread]);
 
   useEffect(() => {
-    loadConversations();
-  }, [loadConversations]); // Initial load
-
-  // Removed useEffect for location.state handling (project-based chat initiation)
+    loadThreads();
+  }, [loadThreads]);
 
   useEffect(() => {
     const loadMessages = async () => {
-      if (selectedConversation && user) {
+      if (selectedThread && user) {
         setIsLoadingMessages(true); setError(null);
         try {
-          const convMessages = await fetchConversationMessagesAPI(selectedConversation.conversation_id, { limit: 100 }); // Increased limit
-          setMessages(convMessages);
+          // The fetchThreadMessagesAPI now handles marking messages as read on backend
+          const threadMessages = await fetchThreadMessagesAPI(selectedThread.thread_id, { limit: 100 });
+          setMessages(threadMessages);
 
-          if (selectedConversation.unread_message_count > 0) {
-            await markConversationAsReadAPI(selectedConversation.conversation_id);
-            // Update unread count locally for immediate UI feedback
-            const convIdx = conversations.findIndex(c => c.conversation_id === selectedConversation.conversation_id);
-            if (convIdx !== -1) {
-                const newConversations = [...conversations];
-                newConversations[convIdx] = {...newConversations[convIdx], unread_message_count: 0};
-                setConversations(newConversations);
-            }
+          // If unread_count was positive, refresh threads list to get updated unread_count
+          if (selectedThread.unread_count > 0) {
+            loadThreads(selectedThread.thread_id); // Reload threads to reflect new unread counts
           }
-        } catch (err:any) {
+        } catch (err: any) {
           console.error("Failed to load messages:", err);
           setError(err.message || "Could not load messages for this chat.");
         } finally {
@@ -135,24 +119,39 @@ const MessagingPage: React.FC = () => {
       }
     };
     loadMessages();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedConversation, user]); // Removed 'conversations' from dep array to avoid loop with unread update
+  }, [selectedThread, user, loadThreads]);
 
 
   const handleSendMessage = async () => {
-    if (!newMessageContent.trim() || !selectedConversation || !user) return;
+    if (!newMessageContent.trim() || !selectedThread || !user) return;
     setIsSendingMessage(true); setError(null);
-    const payload: SendMessagePayload = {
-      conversation_id: selectedConversation.conversation_id,
+
+    const payload: SendThreadMessagePayload = {
+      thread_id: selectedThread.thread_id,
       content: newMessageContent.trim(),
+      // project_id and thread_type_hint are not needed when sending to an existing thread_id
     };
+
     try {
-      const sentMessage = await sendMessageAPI(payload);
-      setMessages(prev => [...prev, sentMessage]);
+      const response = await sendThreadMessageAPI(payload);
+      // Add the new message optimistically if backend doesn't return full message object
+      // Or better, backend returns the created message object
+      const optimisticMessage: ThreadMessage = {
+        id: response.message_id || Date.now(), // Use actual ID from response, fallback for optimism
+        thread_id: selectedThread.thread_id,
+        sender_id: user.id,
+        sender_username: user.username,
+        // sender_avatar_url: user.avatarUrl, // If available on user object
+        content: newMessageContent.trim(),
+        sent_at: new Date().toISOString(),
+        requires_approval: response.requires_approval || false,
+        approval_status: response.approval_status || null,
+      };
+      setMessages(prev => [...prev, optimisticMessage]);
       setNewMessageContent('');
-      // Reload conversations to update last message preview and sorting
-      await loadConversations(selectedConversation.conversation_id);
-    } catch (err:any) {
+      // Reload threads to update last message preview and sorting
+      loadThreads(selectedThread.thread_id);
+    } catch (err: any) {
       console.error("Failed to send message:", err);
       setError(err.message || "Failed to send message.");
     } finally {
@@ -160,72 +159,87 @@ const MessagingPage: React.FC = () => {
     }
   };
 
-  // Removed handleAdminMessageAction as admin moderation is simplified/removed for now
+  const getThreadDisplayName = (thread: MessageThread): string => {
+    if (!user) return "Chat";
+    if (thread.title) return thread.title; // Use custom thread title if available (e.g. for project threads)
 
-  const getConversationDisplayName = (conv: ConversationPreviewPHP): string => {
-    if (!user) return "Conversation";
-    
-    // For 1-on-1 chats, display the other participant's name
-    const otherParticipants = conv.participants.filter(p => p.id !== user.id);
+    // For 'direct' threads, generate name from other participants
+    if (thread.type === 'direct') {
+      const otherParticipants = thread.participants.filter(p => p.id !== user.id);
+      if (otherParticipants.length > 0) {
+        return otherParticipants.map(p => p.username).join(', ');
+      }
+      return "Chat with Yourself"; // Should not happen often
+    }
+    return thread.project_title ? `Project: ${thread.project_title}` : "Chat"; // Fallback for project threads without custom title
+  };
+
+  const getOtherParticipantAvatarName = (thread: MessageThread): string => {
+    if (!user) return "C";
+    const otherParticipants = thread.participants.filter(p => p.id !== user.id);
     if (otherParticipants.length === 1) {
       return otherParticipants[0].username;
     }
-    // Fallback for group chats or unexpected scenarios (though backend primarily creates 1-on-1)
-    if (conv.participants.length > 1) {
-      return conv.participants.map(p => p.username).join(', ');
-    }
-    return "Conversation"; // Should ideally not happen with valid data
+    if (thread.participants.length > 1) return "Group"; // For group DMs or project chats
+    return thread.title || "Chat"; // Fallback
   };
 
-  const getOtherParticipantAvatarName = (conv: ConversationPreviewPHP): string => {
-    if (!user) return "C"; // Fallback for Conversation
-    const otherParticipants = conv.participants.filter(p => p.id !== user.id);
-    if (otherParticipants.length === 1) {
-      return otherParticipants[0].username;
-    }
-    return "Group"; // Fallback for group or self-chat
-  };
-
-
-  const handleOpenCreateConversationModal = async () => {
-      setIsCreateConversationModalOpen(true);
-      setSearchTermForNewConversation('');
-      setIsLoadingConversations(true); // Use conversation loader for user list loading
-      try {
-          const allUsers = await adminFetchAllUsersAPI();
-          if(user) {
-            setUsersForNewConversation(allUsers.filter(u => u.id !== user.id));
-          } else {
-            setUsersForNewConversation(allUsers);
-          }
-      } catch (err) {
-          setError("Could not load users to start a new chat.");
-      } finally {
-        setIsLoadingConversations(false);
+  const handleOpenCreateChatModal = async () => {
+    setIsCreateChatModalOpen(true);
+    setSearchTermForNewChat('');
+    setIsLoadingThreads(true); // Re-use for loading user list state
+    setError(null);
+    try {
+      // Call getMessageableUsersAPI - backend handles filtering based on user role
+      const messageableUsers = await getMessageableUsersAPI();
+      if (user) {
+        // Filter out the current user from the list of messageable users
+        setUsersForNewChat(messageableUsers.filter(u => u.id !== user.id));
+      } else {
+        setUsersForNewChat(messageableUsers); // Should not happen if page is protected
       }
+    } catch (err: any) {
+      setError(err.message || "Could not load users to start a new chat.");
+      console.error("Error fetching messageable users:", err);
+    } finally {
+      setIsLoadingThreads(false);
+    }
   };
 
-  const handleSelectUserForNewConversation = async (recipient: AdminUserView) => {
-      setIsCreateConversationModalOpen(false);
-      if (!user) { setError("You must be logged in."); return; }
-      setIsCreatingConversation(true); setError(null);
-      try {
-          const response = await findOrCreateConversationAPI(recipient.id);
-          // Refresh conversation list and select the new/found one
-          // setSelectedConversation(null); // Deselect current to ensure useEffect for messages re-triggers correctly if same ID
-          await loadConversations(response.conversation_id); // This will also set selectedConversation if found
-          // The loadConversations should ideally handle setting the selectedConversation
-          // If not, manual find and set might be needed, but it's better if loadConversations does it.
-      } catch (err:any) {
-          setError(err.message || "Could not start or find conversation.");
-      } finally {
-        setIsCreatingConversation(false);
-      }
+  const handleSelectUserForNewChat = async (recipient: UserToChatWith) => {
+    setIsCreateChatModalOpen(false);
+    if (!user) { setError("You must be logged in."); return; }
+    setIsCreatingChat(true); setError(null);
+
+    // Validate if non-admin user is trying to DM a non-admin (though list should be pre-filtered)
+    if ((user.role === 'freelancer' || user.role === 'client') && recipient.role !== 'admin') {
+        setError("Freelancers and Clients can only initiate direct messages with Admins.");
+        setIsCreatingChat(false);
+        return;
+    }
+
+    try {
+      const payload: SendThreadMessagePayload = {
+        target_user_ids: [recipient.id], // recipient.id is number, API expects number[]
+        thread_type_hint: 'direct',
+        // Sending an initial message is optional; backend can create empty thread too.
+        // For this example, let's assume an initial message is not strictly required to create the thread.
+        // If content is required, add: content: `Chat started with ${recipient.username}`
+      };
+      const response = await sendThreadMessageAPI(payload);
+      // After successfully creating/finding the thread, load all threads again and select the new/found one.
+      loadThreads(response.thread_id);
+    } catch (err: any) {
+      setError(err.message || "Could not start or find chat.");
+      console.error("Error selecting user for new chat:", err);
+    } finally {
+      setIsCreatingChat(false);
+    }
   };
 
-  const filteredUsersForNewConvo = usersForNewConversation.filter(u =>
-      u.username.toLowerCase().includes(searchTermForNewConversation.toLowerCase()) ||
-      u.email.toLowerCase().includes(searchTermForNewConversation.toLowerCase())
+  const filteredUsersForNewChat = usersForNewChat.filter(u =>
+    u.username.toLowerCase().includes(searchTermForNewChat.toLowerCase()) ||
+    (u.email && u.email.toLowerCase().includes(searchTermForNewChat.toLowerCase()))
   );
 
 
@@ -234,103 +248,127 @@ const MessagingPage: React.FC = () => {
       {error && <div className="p-2 text-center text-red-600 bg-red-100 border-b">{error} <Button variant="ghost" size="sm" onClick={() => setError(null)} className="ml-2 !text-red-600">Dismiss</Button></div>}
 
       <div className="flex flex-1 overflow-hidden">
-        {/* Conversations List Pane */}
-        <div className={`w-full md:w-1/3 lg:w-1/4 border-r border-gray-200 bg-white flex flex-col ${selectedConversation && 'hidden md:flex'}`}>
+        {/* Threads List Pane */}
+        <div className={`w-full md:w-1/3 lg:w-1/4 border-r border-gray-200 bg-white flex flex-col ${selectedThread && 'hidden md:flex'}`}>
           <div className="p-3 border-b flex justify-between items-center">
             <h2 className="text-xl font-semibold text-primary">Chats</h2>
-            <Button size="sm" variant="outline" onClick={handleOpenCreateConversationModal} leftIcon={<UsersIcon />} disabled={isCreatingConversation || isLoadingConversations}>
+            <Button size="sm" variant="outline" onClick={handleOpenCreateChatModal} leftIcon={<UsersIcon />} disabled={isCreatingChat || isLoadingThreads}>
               New Chat
             </Button>
           </div>
           <div className="flex-1 overflow-y-auto">
-            {isLoadingConversations && conversations.length === 0 && <LoadingSpinner text="Loading chats..." className="p-4" />}
-            {!isLoadingConversations && conversations.length === 0 && <div className="p-4 text-center text-gray-500">No conversations yet. Start one with "New Chat".</div>}
-            {conversations.map(conv => (
+            {isLoadingThreads && threads.length === 0 && <LoadingSpinner text="Loading chats..." className="p-4" />}
+            {!isLoadingThreads && threads.length === 0 && <div className="p-4 text-center text-gray-500">No chats yet. Start one with "New Chat".</div>}
+            {threads.map(thread => (
               <div
-                key={conv.conversation_id}
+                key={thread.thread_id}
                 className={`p-3 hover:bg-primary-extralight cursor-pointer border-b border-gray-100
-                            ${selectedConversation?.conversation_id === conv.conversation_id ? 'bg-accent' : ''}
-                            ${conv.unread_message_count > 0 ? 'font-semibold' : ''}`}
-                onClick={() => setSelectedConversation(conv)}
+                            ${selectedThread?.thread_id === thread.thread_id ? 'bg-accent' : ''}
+                            ${thread.unread_count > 0 ? 'font-semibold' : ''}`}
+                onClick={() => setSelectedThread(thread)}
               >
                 <div className="flex items-center space-x-3">
                   <img
-                    src={`https://ui-avatars.com/api/?name=${getOtherParticipantAvatarName(conv).replace(/\s+/g, '+')}&background=A6C4BD&color=2A5B53&rounded=true&font-size=0.5`}
+                    src={thread.participants.find(p => p.id !== user?.id)?.avatar_url || `https://ui-avatars.com/api/?name=${getOtherParticipantAvatarName(thread).replace(/\s+/g, '+')}&background=A6C4BD&color=2A5B53&rounded=true&font-size=0.5`}
                     alt="avatar"
-                    className="w-10 h-10 rounded-full"
+                    className="w-10 h-10 rounded-full object-cover"
                   />
                   <div className="flex-1 min-w-0">
                     <div className="flex justify-between items-center">
-                        <p className={`text-sm ${conv.unread_message_count > 0 ? 'text-primary' : 'text-gray-800'} truncate`}>
-                            {getConversationDisplayName(conv)}
-                        </p>
-                        {conv.unread_message_count > 0 && (
-                            <span className="ml-2 text-xs bg-accent text-primary-dark font-bold px-1.5 py-0.5 rounded-full">
-                                {conv.unread_message_count}
-                            </span>
-                        )}
+                      <p className={`text-sm ${thread.unread_count > 0 ? 'text-primary' : 'text-gray-800'} truncate`}>
+                        {getThreadDisplayName(thread)}
+                      </p>
+                      {thread.unread_count > 0 && (
+                        <span className="ml-2 text-xs bg-accent text-primary-dark font-bold px-1.5 py-0.5 rounded-full">
+                          {thread.unread_count}
+                        </span>
+                      )}
                     </div>
-                    <p className={`text-xs ${conv.unread_message_count > 0 ? 'text-primary-dark' : 'text-gray-500'} truncate`}>
-                        {conv.last_message_sender_id === user?.id ? 'You: ' : ''}{conv.last_message_snippet || 'No messages yet.'}
+                    <p className={`text-xs ${thread.unread_count > 0 ? 'text-primary-dark' : 'text-gray-500'} truncate`}>
+                      {thread.last_message_sender_id === user?.id ? 'You: ' : ''}{thread.last_message_snippet || 'No messages yet.'}
                     </p>
                   </div>
-                  <div className="text-xs text-gray-400 self-start">{formatMessageTimestamp(conv.last_message_at)}</div>
+                  <div className="text-xs text-gray-400 self-start">{formatMessageTimestamp(thread.last_message_at)}</div>
                 </div>
               </div>
             ))}
-             {isCreatingConversation && <LoadingSpinner text="Starting chat..." className="p-4"/>}
+            {isCreatingChat && <LoadingSpinner text="Starting chat..." className="p-4" />}
           </div>
         </div>
 
         {/* Message Display Pane */}
-        <div className={`flex-1 flex flex-col bg-gray-100 ${!selectedConversation ? 'hidden md:flex md:items-center md:justify-center' : 'flex'}`}>
-          {selectedConversation && (
-            <div className="p-2 border-b md:hidden bg-white sticky top-0 z-10"> {/* Mobile: Back button bar */}
-              <Button variant="ghost" onClick={() => setSelectedConversation(null)} leftIcon={<ArrowLeftIcon />}>
+        <div className={`flex-1 flex flex-col bg-gray-100 ${!selectedThread ? 'hidden md:flex md:items-center md:justify-center' : 'flex'}`}>
+          {selectedThread && (
+            <div className="p-2 border-b md:hidden bg-white sticky top-0 z-10">
+              <Button variant="ghost" onClick={() => setSelectedThread(null)} leftIcon={<ArrowLeftIcon />}>
                 Back to Chats
               </Button>
             </div>
           )}
-          {!selectedConversation ? (
+          {!selectedThread ? (
             <div className="text-center text-gray-500 p-5">
-              <ChatBubbleLeftRightIcon className="w-20 h-20 mx-auto mb-4 text-gray-300"/>
-              <p>Select a conversation to start chatting or create a new one.</p>
+              <ChatBubbleLeftRightIcon className="w-20 h-20 mx-auto mb-4 text-gray-300" />
+              <p>Select a chat to view messages or create a new one.</p>
             </div>
           ) : (
             <>
-              <div className="p-3 bg-white border-b border-gray-200 flex items-center space-x-3 sticky top-0 z-10 md:static"> {/* Header for selected chat */}
-                 <img
-                    src={`https://ui-avatars.com/api/?name=${getOtherParticipantAvatarName(selectedConversation).replace(/\s+/g, '+')}&background=A6C4BD&color=2A5B53&rounded=true&font-size=0.5`}
-                    alt="avatar"
-                    className="w-9 h-9 rounded-full"
-                  />
-                <h3 className="text-lg font-semibold text-gray-700">{getConversationDisplayName(selectedConversation)}</h3>
+              <div className="p-3 bg-white border-b border-gray-200 flex items-center space-x-3 sticky top-0 z-10 md:static">
+                <img
+                  src={selectedThread.participants.find(p => p.id !== user?.id)?.avatar_url || `https://ui-avatars.com/api/?name=${getOtherParticipantAvatarName(selectedThread).replace(/\s+/g, '+')}&background=A6C4BD&color=2A5B53&rounded=true&font-size=0.5`}
+                  alt="avatar"
+                  className="w-9 h-9 rounded-full object-cover"
+                />
+                <div className="flex-1">
+                    <h3 className="text-lg font-semibold text-gray-700">{getThreadDisplayName(selectedThread)}</h3>
+                    {selectedThread.project_id && selectedThread.type !== 'direct' && (
+                         <p className="text-xs text-gray-500">Project: {selectedThread.project_title || `ID ${selectedThread.project_id}`}</p>
+                    )}
+                </div>
+                {selectedThread.project_id && selectedThread.type !== 'direct' && (
+                     <Button
+                        variant="outline"
+                        size="xs"
+                        onClick={() => window.open(`/#/dashboard/projects/${selectedThread.project_id}/files`, '_blank')}
+                        title="Open project files in new tab"
+                    >
+                        Project Files
+                    </Button>
+                )}
               </div>
-              <div className="flex-1 p-4 space-y-3 overflow-y-auto bg-gray-50">
-                {isLoadingMessages && <LoadingSpinner text="Loading messages..." className="p-4"/>}
+              <div className="flex-1 p-4 space-y-3 overflow-y-auto bg-gray-50 min-h-[300px]">
+                {isLoadingMessages && <LoadingSpinner text="Loading messages..." className="p-4" />}
                 {!isLoadingMessages && messages.length === 0 && <div className="text-center text-gray-400 p-4">No messages yet. Send one to start the conversation!</div>}
                 {messages.map(msg => {
                   const isSender = msg.sender_id === user?.id;
+                  let approvalText = '';
+                  if (isSender && msg.requires_approval) {
+                    if (msg.approval_status === 'pending') approvalText = '(Pending Approval)';
+                    else if (msg.approval_status === 'rejected') approvalText = '(Rejected by Admin)';
+                  }
+
                   return (
                     <div key={msg.id} className={`flex ${isSender ? 'justify-end' : 'justify-start'}`}>
                       <div className={`max-w-xs lg:max-w-md p-2.5 rounded-lg shadow ${isSender ? 'bg-primary text-white rounded-br-none' : 'bg-white text-gray-700 rounded-bl-none'}`}>
                         {!isSender && <p className="text-xs font-semibold mb-0.5 text-secondary">{msg.sender_username}</p>}
                         <p className="text-sm whitespace-pre-wrap">{msg.content}</p>
-                        <p className={`text-xs mt-1 ${isSender ? 'text-gray-200 text-right' : 'text-gray-400 text-left'}`}>{formatMessageTimestamp(msg.created_at)}</p>
-                        {/* Admin moderation UI removed */}
+                        <div className="flex justify-between items-center mt-1">
+                          <p className={`text-xs ${isSender ? 'text-gray-200' : 'text-gray-400'}`}>{formatMessageTimestamp(msg.sent_at)}</p>
+                          {approvalText && (
+                            <span className={`text-xs italic ml-2 ${msg.approval_status === 'rejected' ? 'text-red-300' : 'text-gray-300'}`}>
+                              {msg.approval_status === 'pending' && <ClockIcon className="inline w-3 h-3 mr-1" />}
+                              {msg.approval_status === 'rejected' && <XCircleIcon className="inline w-3 h-3 mr-1" />}
+                              {approvalText}
+                            </span>
+                          )}
+                        </div>
                       </div>
                     </div>
                   );
                 })}
                 <div ref={messagesEndRef} />
               </div>
-              <div className="p-3 bg-white border-t border-gray-200 sticky bottom-0 z-10"> {/* Message Input Area */}
+              <div className="p-3 bg-white border-t border-gray-200 sticky bottom-0 z-10">
                 <div className="flex items-center space-x-2">
-                  {/* File attach button (placeholder for now)
-                  <Button variant="ghost" onClick={() => alert("File attachment not implemented yet.")} className="p-2">
-                    <PaperClipIcon className="w-5 h-5 text-gray-500 hover:text-primary"/>
-                  </Button>
-                  */}
                   <input
                     type="text"
                     value={newMessageContent}
@@ -341,7 +379,7 @@ const MessagingPage: React.FC = () => {
                     disabled={isSendingMessage || isLoadingMessages}
                   />
                   <Button onClick={handleSendMessage} disabled={!newMessageContent.trim() || isSendingMessage || isLoadingMessages} isLoading={isSendingMessage} className="p-2.5">
-                    <PaperAirplaneIcon className="w-5 h-5"/>
+                    <PaperAirplaneIcon className="w-5 h-5" />
                   </Button>
                 </div>
               </div>
@@ -349,26 +387,26 @@ const MessagingPage: React.FC = () => {
           )}
         </div>
 
-        {/* Create New Conversation Modal */}
-        <Modal isOpen={isCreateConversationModalOpen} onClose={() => setIsCreateConversationModalOpen(false)} title="Start a New Chat">
+        {/* Create New Chat Modal (for Direct Messages) */}
+        <Modal isOpen={isCreateChatModalOpen} onClose={() => setIsCreateChatModalOpen(false)} title="Start a New Direct Chat">
             <input
                 type="text"
                 placeholder="Search users by name or email..."
-                value={searchTermForNewConversation}
-                onChange={(e) => setSearchTermForNewConversation(e.target.value)}
+                value={searchTermForNewChat}
+                onChange={(e) => setSearchTermForNewChat(e.target.value)}
                 className="w-full p-2 border border-gray-300 rounded-md mb-3"
             />
-            {isLoadingConversations && <LoadingSpinner text="Loading users..." />}
+            {isLoadingThreads && <LoadingSpinner text="Loading users..." />} {/* Re-using isLoadingThreads */}
             <div className="max-h-60 overflow-y-auto">
-                {filteredUsersForNewConvo.length === 0 && !isLoadingConversations && <p className="text-gray-500">No users found matching your search.</p>}
-                {filteredUsersForNewConvo.map(u => (
+                {filteredUsersForNewChat.length === 0 && !isLoadingThreads && <p className="text-gray-500">No users found.</p>}
+                {filteredUsersForNewChat.map(u => (
                     <div key={u.id}
                          className="p-2 hover:bg-gray-100 cursor-pointer rounded-md flex items-center space-x-2"
-                         onClick={() => handleSelectUserForNewConversation(u)}>
+                         onClick={() => handleSelectUserForNewChat(u)}>
                         <img
-                            src={`https://ui-avatars.com/api/?name=${u.username.replace(/\s+/g, '+')}&background=random&color=fff&rounded=true&size=32`}
+                            src={u.avatarUrl || `https://ui-avatars.com/api/?name=${u.username.replace(/\s+/g, '+')}&background=random&color=fff&rounded=true&size=32`}
                             alt={u.username}
-                            className="w-8 h-8 rounded-full"
+                            className="w-8 h-8 rounded-full object-cover"
                         />
                         <div>
                             <p className="font-medium">{u.username}</p>
@@ -378,18 +416,9 @@ const MessagingPage: React.FC = () => {
                 ))}
             </div>
             <div className="text-right mt-4">
-                <Button variant="secondary" onClick={() => setIsCreateConversationModalOpen(false)}>Cancel</Button>
+                <Button variant="secondary" onClick={() => setIsCreateChatModalOpen(false)}>Cancel</Button>
             </div>
         </Modal>
-
-        {/* Attach file modal (placeholder) - can be removed if not part of this phase
-        <Modal isOpen={isAttachFileModalOpen} onClose={() => setIsAttachFileModalOpen(false)} title="Attach File">
-            <p className="text-gray-600">File upload in chat is not yet implemented. This is a placeholder.</p>
-            <div className="text-right mt-4">
-                <Button onClick={() => setIsAttachFileModalOpen(false)}>Close</Button>
-            </div>
-        </Modal>
-        */}
       </div>
     </div>
   );

--- a/components/admin/AdminProjectMessagingPage.tsx
+++ b/components/admin/AdminProjectMessagingPage.tsx
@@ -1,0 +1,392 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '../AuthContext'; // Adjusted path
+import { getProjectsAPI, Project } from '../../apiService'; // Adjusted path
+import LoadingSpinner from '../shared/LoadingSpinner'; // Adjusted path
+import Button from '../shared/Button'; // Adjusted path
+import { ChatBubbleLeftRightIcon, ChevronDownIcon, ChevronUpIcon, PaperAirplaneIcon, HandThumbUpIcon, HandThumbDownIcon, EyeIcon, EyeSlashIcon } from '../shared/IconComponents'; // Adjusted path
+
+import {
+    Project,
+    MessageThread as ApiMessageThread, // Rename to avoid conflict with local interface if any
+    ThreadMessage as ApiThreadMessage, // Rename
+    fetchUserMessageThreadsAPI, // Will be used to find existing threads for a project
+    fetchThreadMessagesAPI,
+    sendThreadMessageAPI,
+    SendThreadMessagePayload,
+    moderateMessageAPI,
+    ModerateMessagePayload,
+    getProjectsAPI, // Already imported
+} from '../../apiService'; // Adjusted path
+import LoadingSpinner from '../shared/LoadingSpinner'; // Adjusted path
+import Button from '../shared/Button'; // Adjusted path
+import { ChatBubbleLeftRightIcon, PaperAirplaneIcon, HandThumbUpIcon, HandThumbDownIcon, UsersIcon, BuildingStorefrontIcon, UserGroupIcon } from '../shared/IconComponents'; // Adjusted path
+
+// Use ApiMessageThread and ApiThreadMessage directly or create local versions if transformation is needed
+type LocalMessageThread = ApiMessageThread; // Alias for clarity
+type LocalThreadMessage = ApiThreadMessage;
+
+const AdminProjectMessagingPage: React.FC = () => {
+  const { user } = useAuth();
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
+  const [isLoadingProjects, setIsLoadingProjects] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // State for the three distinct thread types
+  const [clientAdminFreelancerThread, setClientAdminFreelancerThread] = useState<LocalMessageThread | null>(null); // Type A
+  const [adminClientThread, setAdminClientThread] = useState<LocalMessageThread | null>(null); // Type B
+  const [adminFreelancerThread, setAdminFreelancerThread] = useState<LocalMessageThread | null>(null); // Type C
+
+  const [messagesMap, setMessagesMap] = useState<Record<number, LocalThreadMessage[]>>({}); // thread.thread_id (number) -> messages
+  const [newMessageContent, setNewMessageContent] = useState<Record<number, string>>({}); // thread.thread_id (number) -> content
+  const [isLoadingThreads, setIsLoadingThreads] = useState(false);
+  const [isLoadingMessages, setIsLoadingMessages] = useState<Record<number, boolean>>({}); // thread.thread_id (number) -> boolean
+
+  // This state is removed as visibility is now handled by distinct thread types or backend permissions.
+  // const [freelancerCanViewClientChat, setFreelancerCanViewClientChat] = useState(true);
+
+  const fetchProjects = useCallback(async () => {
+    setIsLoadingProjects(true);
+    setError(null);
+    try {
+      const fetchedProjects = await getProjectsAPI({ status: 'all' }); // Fetch all projects for admin
+      setProjects(fetchedProjects);
+    } catch (err: any) {
+      setError(err.message || 'Failed to fetch projects.');
+      console.error("Failed to fetch projects:", err);
+    } finally {
+      setIsLoadingProjects(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchProjects();
+  }, [fetchProjects]);
+
+  const handleSelectProject = (project: Project) => {
+    setSelectedProject(project);
+    setAdminFreelancerThread(null);
+    setAdminClientThread(null);
+    setClientAdminFreelancerThread(null);
+    setMessagesMap({});
+    setNewMessageContent({});
+    fetchProjectThreads(project.id);
+  };
+
+  const fetchProjectThreads = useCallback(async (projectId: number) => {
+    setIsLoadingThreads(true);
+    setError(null);
+    try {
+      // This API fetches all threads for the current user.
+      // We need to filter them for the selected project and by type.
+      // Or, ideally, a new backend endpoint like `get_project_message_threads_for_admin` would be better.
+      // For now, we simulate finding/initializing them.
+      const allUserThreads = await fetchUserMessageThreadsAPI();
+
+      const cafThread = allUserThreads.find(t => t.project_id === projectId && t.type === 'project_client_admin_freelancer');
+      setClientAdminFreelancerThread(cafThread || null); // Or a placeholder to initiate creation
+
+      const acThread = allUserThreads.find(t => t.project_id === projectId && t.type === 'project_admin_client');
+      setAdminClientThread(acThread || null);
+
+      const afThread = allUserThreads.find(t => t.project_id === projectId && t.type === 'project_admin_freelancer');
+      setAdminFreelancerThread(afThread || null);
+
+    } catch (err: any) {
+      setError(err.message || `Failed to fetch threads for project ${projectId}.`);
+      console.error("Failed to fetch project threads:", err);
+    } finally {
+      setIsLoadingThreads(false);
+    }
+  }, []);
+
+  const fetchMessagesForThread = useCallback(async (threadId: number) => {
+    if (!threadId) return;
+    setIsLoadingMessages(prev => ({ ...prev, [threadId]: true }));
+    setError(null);
+    try {
+      const fetchedMessages = await fetchThreadMessagesAPI(threadId, { limit: 100 });
+      setMessagesMap(prev => ({ ...prev, [threadId]: fetchedMessages }));
+    } catch (err: any) {
+      setError(err.message || `Failed to load messages for thread ${threadId}.`);
+      console.error(`Failed to load messages for thread ${threadId}:`, err);
+    } finally {
+      setIsLoadingMessages(prev => ({ ...prev, [threadId]: false }));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (clientAdminFreelancerThread?.thread_id && !messagesMap[clientAdminFreelancerThread.thread_id]) {
+      fetchMessagesForThread(clientAdminFreelancerThread.thread_id);
+    }
+  }, [clientAdminFreelancerThread, messagesMap, fetchMessagesForThread]);
+
+  useEffect(() => {
+    if (adminClientThread?.thread_id && !messagesMap[adminClientThread.thread_id]) {
+      fetchMessagesForThread(adminClientThread.thread_id);
+    }
+  }, [adminClientThread, messagesMap, fetchMessagesForThread]);
+
+  useEffect(() => {
+    if (adminFreelancerThread?.thread_id && !messagesMap[adminFreelancerThread.thread_id]) {
+      fetchMessagesForThread(adminFreelancerThread.thread_id);
+    }
+  }, [adminFreelancerThread, messagesMap, fetchMessagesForThread]);
+
+  const handleSendMessage = async (thread: LocalMessageThread | null, threadTypeHint: SendThreadMessagePayload['thread_type_hint']) => {
+    if (!selectedProject || !user) return;
+    const threadId = thread?.thread_id;
+    const content = newMessageContent[threadId || 0]; // Use 0 as a temp key if threadId is null
+
+    if (!content?.trim()) return;
+
+    const payload: SendThreadMessagePayload = {
+      project_id: selectedProject.id,
+      content: content.trim(),
+      thread_type_hint: threadTypeHint,
+    };
+    if (threadId) {
+      payload.thread_id = threadId;
+    }
+
+    // For Admin-Client (Type B), the backend now handles freelancer visibility based on thread participation.
+    // The `admin_client_message_freelancer_visibility` is primarily for initial thread creation by admin.
+    // If sending to an existing Type B thread, this field is less relevant from frontend for *this specific message*.
+
+    // Optimistic UI update
+    const tempMessage: LocalThreadMessage = {
+        id: Date.now(), // Temporary ID
+        thread_id: threadId || 0, // Use actual or temporary
+        sender_id: user.id,
+        sender_username: user.username,
+        content: content.trim(),
+        sent_at: new Date().toISOString(),
+        requires_approval: false, // Admin messages don't require approval
+        approval_status: null,
+    };
+
+    if (threadId) {
+        setMessagesMap(prev => ({ ...prev, [threadId]: [...(prev[threadId] || []), tempMessage] }));
+    }
+    setNewMessageContent(prev => ({ ...prev, [threadId || 0]: '' }));
+
+    try {
+      const response = await sendThreadMessageAPI(payload);
+      // If a new thread was created, response.thread_id will be the new ID.
+      // We need to update our local thread state and fetch messages for it.
+      if (!threadId && response.thread_id) {
+        fetchProjectThreads(selectedProject.id); // This will re-fetch all threads for the project
+      } else if (threadId) {
+        fetchMessagesForThread(threadId); // Refresh messages for the existing thread
+      }
+    } catch (err: any) {
+      setError(err.message || `Failed to send message.`);
+      // Revert optimistic update if needed, though often just showing error is enough
+      if (threadId) {
+        setMessagesMap(prev => ({ ...prev, [threadId]: prev[threadId]?.filter(m => m.id !== tempMessage.id) || [] }));
+      }
+      console.error("Send message error:", err);
+    }
+  };
+
+  const handleApproveMessage = async (messageId: number, threadId: number) => {
+    const payload: ModerateMessagePayload = { message_id: messageId, approval_status: 'approved' };
+    try {
+      await moderateMessageAPI(payload);
+      fetchMessagesForThread(threadId); // Refresh messages to show updated status
+    } catch (err: any) {
+      setError(err.message || "Failed to approve message.");
+      console.error("Approve message error:", err);
+    }
+  };
+
+  const handleRejectMessage = async (messageId: number, threadId: number) => {
+    const payload: ModerateMessagePayload = { message_id: messageId, approval_status: 'rejected' };
+    try {
+      await moderateMessageAPI(payload);
+      fetchMessagesForThread(threadId); // Refresh messages
+    } catch (err: any) {
+      setError(err.message || "Failed to reject message.");
+      console.error("Reject message error:", err);
+    }));
+  };
+
+  const renderChatInterface = (
+    thread: LocalMessageThread | null,
+    threadTypeForDisplay: string,
+    threadTypeHintApi: SendThreadMessagePayload['thread_type_hint']
+  ) => {
+    if (!selectedProject) return null;
+
+    const threadExists = !!thread;
+    const currentThreadId = thread?.thread_id || 0; // Use 0 or a unique temp key for new message input if thread is null
+
+    if (isLoadingThreads && !threadExists) return <LoadingSpinner text={`Loading ${threadTypeForDisplay} chat...`} />;
+
+    // If thread is null (doesn't exist yet), show a button to initiate it.
+    if (!threadExists) {
+      return (
+        <div className="p-4 border rounded-lg shadow-sm text-center">
+          <p className="text-gray-500 mb-2">No '{threadTypeForDisplay}' chat started for this project yet.</p>
+          <Button
+            onClick={() => handleSendMessage(null, threadTypeHintApi)}
+            disabled={!selectedProject || !user}
+            size="sm"
+          >
+            Start Chat: {threadTypeForDisplay}
+          </Button>
+        </div>
+      );
+    }
+
+    // Thread exists, proceed to render chat.
+    const currentMessages = messagesMap[currentThreadId] || [];
+    const currentNewMessage = newMessageContent[currentThreadId] || '';
+
+    return (
+      <div className="flex flex-col h-full border rounded-lg shadow-sm">
+        <div className="p-3 bg-slate-100 border-b rounded-t-lg flex justify-between items-center">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-700">
+              {thread.title || threadTypeForDisplay}
+              {thread.project_id && <span className="text-sm text-slate-500 ml-2">(Project: {selectedProject?.title})</span>}
+            </h3>
+          </div>
+          {selectedProject && thread.project_id && (
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={() => window.open(`/#/dashboard/projects/${selectedProject.id}/files`, '_blank')} // Assuming a conventional path
+              title="Open project files in new tab"
+            >
+              Project Files
+            </Button>
+          )}
+        </div>
+        <div className="flex-grow p-4 space-y-3 overflow-y-auto bg-white min-h-[300px]">
+          {isLoadingMessages[currentThreadId] && <LoadingSpinner text="Loading messages..." />}
+          {!isLoadingMessages[currentThreadId] && currentMessages.length === 0 && <div className="text-center text-gray-400">No messages yet.</div>}
+          {currentMessages.map(msg => (
+            <div key={msg.id} className={`flex ${msg.sender_id === user!.id ? 'justify-end' : 'justify-start'}`}>
+              <div className={`max-w-lg p-2.5 rounded-lg shadow-sm ${msg.sender_id === user!.id ? 'bg-primary text-white rounded-br-none' : 'bg-slate-50 text-slate-700 rounded-bl-none'}`}>
+                <p className="text-xs font-semibold mb-0.5 text-secondary-dark">{msg.sender_username}</p>
+                <p className="text-sm whitespace-pre-wrap">{msg.content}</p>
+                <p className={`text-xs mt-1 ${msg.sender_id === user!.id ? 'text-gray-200 text-right' : 'text-slate-400 text-left'}`}>{new Date(msg.sent_at).toLocaleTimeString()}</p>
+                {/* Admin moderation UI for messages from others that require approval */}
+                {msg.requires_approval && msg.sender_id !== user!.id && msg.approval_status === 'pending' && (
+                  <div className="mt-2 pt-2 border-t border-slate-200">
+                    <p className="text-xs text-amber-600 italic">This message requires your approval.</p>
+                    <div className="flex space-x-2 mt-1">
+                      <Button size="xs" variant="success" onClick={() => handleApproveMessage(msg.id, currentThreadId)} leftIcon={<HandThumbUpIcon />}>Approve</Button>
+                      <Button size="xs" variant="danger" onClick={() => handleRejectMessage(msg.id, currentThreadId)} leftIcon={<HandThumbDownIcon />}>Reject</Button>
+                    </div>
+                  </div>
+                )}
+                 {msg.approval_status === 'rejected' && msg.sender_id !== user!.id && (
+                     <p className="text-xs text-red-500 italic mt-1">You rejected this message.</p>
+                 )}
+                 {msg.approval_status === 'approved' && msg.requires_approval && msg.sender_id !== user!.id && (
+                     <p className="text-xs text-green-500 italic mt-1">You approved this message.</p>
+                 )}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="p-3 bg-slate-50 border-t rounded-b-lg">
+          <div className="flex items-center space-x-2">
+            <input
+              type="text"
+              value={currentNewMessage}
+              onChange={(e) => setNewMessageContent(prev => ({ ...prev, [currentThreadId]: e.target.value }))}
+              onKeyPress={(e) => e.key === 'Enter' && !e.shiftKey && (e.preventDefault(), handleSendMessage(thread, threadTypeHintApi))}
+              placeholder="Type your message..."
+              className="flex-1 p-2 border border-slate-300 rounded-lg focus:ring-primary-dark focus:border-primary-dark text-sm"
+            />
+            <Button onClick={() => handleSendMessage(thread, threadTypeHintApi)} disabled={!currentNewMessage.trim()} className="p-2">
+              <PaperAirplaneIcon className="w-5 h-5" />
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  // Helper to get an icon for each thread type
+  const getThreadIcon = (type: LocalMessageThread['type']) => {
+    switch(type) {
+        case 'project_client_admin_freelancer': return <UserGroupIcon className="w-5 h-5 mr-2 text-slate-500" />;
+        case 'project_admin_client': return <BuildingStorefrontIcon className="w-5 h-5 mr-2 text-slate-500" />;
+        case 'project_admin_freelancer': return <UsersIcon className="w-5 h-5 mr-2 text-slate-500" />;
+        default: return <ChatBubbleLeftRightIcon className="w-5 h-5 mr-2 text-slate-500" />;
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-4 md:p-6">
+      <h1 className="text-2xl font-semibold text-slate-800 mb-6">Admin Project Messaging</h1>
+      {error && <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">{error}</div>}
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {/* Project List */}
+        <div className="md:col-span-1 bg-white p-4 rounded-lg shadow">
+          <h2 className="text-lg font-semibold text-slate-700 mb-3">Select a Project</h2>
+          {isLoadingProjects && <LoadingSpinner text="Loading projects..." />}
+          {!isLoadingProjects && projects.length === 0 && <p className="text-slate-500">No projects found.</p>}
+          <ul className="space-y-2 max-h-96 overflow-y-auto">
+            {projects.map(p => (
+              <li key={p.id}
+                  onClick={() => handleSelectProject(p)}
+                  className={`p-3 rounded-md cursor-pointer transition-colors
+                              ${selectedProject?.id === p.id ? 'bg-primary text-white shadow-md' : 'bg-slate-50 hover:bg-primary-extralight text-slate-700'}`}>
+                <p className="font-medium">{p.title}</p>
+                <p className={`text-xs ${selectedProject?.id === p.id ? 'text-slate-200' : 'text-slate-500'}`}>Client: {p.client_username || 'N/A'} | Freelancer: {p.freelancer_username || 'N/A'}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Messaging Area */}
+        <div className="md:col-span-2 space-y-6">
+          {!selectedProject ? (
+            <div className="bg-white p-6 rounded-lg shadow text-center text-slate-500">
+              <ChatBubbleLeftRightIcon className="w-16 h-16 mx-auto text-slate-300 mb-4" />
+              <p>Please select a project to view and manage messages.</p>
+            </div>
+          ) : (
+            <>
+              <div className="bg-white p-1 rounded-lg shadow">
+                {renderChatInterface(adminFreelancerThread, "Admin-Freelancer")}
+              </div>
+              <div className="bg-white p-1 rounded-lg shadow">
+                {renderChatInterface(adminClientThread, "Admin-Client")}
+              </div>
+              {/* Placeholder for Freelancer-Client pending approval messages view */}
+              <div className="bg-white p-4 rounded-lg shadow">
+                <h3 className="text-lg font-semibold text-slate-700 mb-2">Freelancer to Client (Pending Approval)</h3>
+                <p className="text-slate-500 text-sm">
+                  {/* TODO: List messages from 'project_freelancer_client' threads that have requires_approval=true and approval_status='pending' */}
+                  Feature to view and moderate these messages will be here.
+                </p>
+              </div>
+            <>
+              <div className="bg-white p-1 rounded-lg shadow">
+                <h4 className="text-md font-medium text-slate-600 p-3 flex items-center"><UserGroupIcon className="w-5 h-5 mr-2 text-slate-500" /> Client / Admin / Freelancer Chat</h4>
+                {renderChatInterface(clientAdminFreelancerThread, "Client/Admin/Freelancer", 'project_client_admin_freelancer')}
+              </div>
+              <div className="bg-white p-1 rounded-lg shadow">
+                 <h4 className="text-md font-medium text-slate-600 p-3 flex items-center"><BuildingStorefrontIcon className="w-5 h-5 mr-2 text-slate-500" /> Admin / Client Only Chat</h4>
+                {renderChatInterface(adminClientThread, "Admin-Client", 'project_admin_client')}
+              </div>
+              <div className="bg-white p-1 rounded-lg shadow">
+                <h4 className="text-md font-medium text-slate-600 p-3 flex items-center"><UsersIcon className="w-5 h-5 mr-2 text-slate-500" /> Admin / Freelancer Only Chat</h4>
+                {renderChatInterface(adminFreelancerThread, "Admin-Freelancer", 'project_admin_freelancer')}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminProjectMessagingPage;

--- a/constants.ts
+++ b/constants.ts
@@ -32,6 +32,7 @@ export const NAV_LINKS = {
   
   ADMIN_USERS: 'users',
   ADMIN_PROJECTS: 'projects',
+  ADMIN_PROJECT_MESSAGING: 'project-messaging', // New constant for Admin Project Messaging
   ADMIN_CREATE_PROJECT: 'create-project', // This path might be deprecated if creation is modal-only
   ADMIN_BILLING: 'billing', 
   ADMIN_TIME_REPORTS: 'time-reports',

--- a/docs/messaging_workflow.md
+++ b/docs/messaging_workflow.md
@@ -1,0 +1,111 @@
+# Messaging Module Workflow (Revised)
+
+This document outlines the revised workflow for the project-based and direct messaging module within the Architex Axis Management Suite. It covers interactions for Admin, Freelancer, and Client roles, focusing on the distinct project thread types and direct messaging restrictions.
+
+## Core Concepts
+
+*   **Message Threads**: Conversations are organized into "threads".
+    *   **Direct Message (DM) Threads (`direct`)**:
+        *   Between an Admin and any other single user (Client, Freelancer, or another Admin).
+        *   Between a Freelancer and an Admin **only**.
+        *   Between a Client and an Admin **only**.
+        *   Freelancers cannot DM other Freelancers or Clients directly.
+        *   Clients cannot DM other Clients or Freelancers directly.
+    *   **Project-Specific Threads**: Linked to a specific project. These threads involve roles determined by the project's assignments (Client, Admin, and potentially multiple Freelancers).
+        1.  **Type A: Client-Admin-Freelancer(s) (`project_client_admin_freelancer`)**:
+            *   Participants: The Project's Client, Admin(s), and **all Freelancers assigned to the project** (via the `project_assigned_freelancers` table).
+            *   Purpose: Collaborative discussion where all key project stakeholders can communicate.
+            *   **Freelancer Message Approval**: Messages sent by **any Freelancer** in this thread type **require Admin approval** before becoming visible to the Client and other non-Admin participants (except the sending freelancer). Admins see all messages.
+            *   File Linking: Linked to a dedicated project folder accessible by Client, Admin, and all assigned Freelancers.
+        2.  **Type B: Admin-Client (`project_admin_client`)**:
+            *   Participants: Admin(s) and the Project Client.
+            *   Purpose: Private communication channel between the Admin and the Client regarding the project.
+            *   Freelancer Access: Freelancers assigned to the project **cannot** view or participate in this thread.
+            *   File Linking: Linked to a dedicated project folder accessible by Admin and Client only (not freelancers).
+        3.  **Type C: Admin-Freelancer(s) (`project_admin_freelancer`)**:
+            *   Participants: Admin(s) and **all Freelancers assigned to the project**.
+            *   Purpose: Private communication channel between the Admin and the assigned Freelancer(s) regarding the project.
+            *   Client Access: The Project Client **cannot** view or participate in this thread.
+            *   File Linking: Linked to a dedicated project folder accessible by Admin and all assigned Freelancers only (not the client).
+
+*   **Message Approval**: A key feature for `project_client_admin_freelancer` (Type A) threads. Messages from any assigned freelancer are held for Admin review before client visibility.
+
+## User Role Workflows
+
+### 1. Admin Workflow
+
+*   **Project Messaging Interface (`AdminProjectMessagingPage.tsx`)**:
+    *   Admin selects a project.
+    *   The UI displays options to view/initiate three distinct chat threads for that project:
+        *   Client-Admin-Freelancer (Type A)
+        *   Admin-Client Only (Type B)
+        *   Admin-Freelancer Only (Type C)
+    *   If a thread doesn't exist, the Admin can initiate it (typically by sending the first message). The backend automatically adds the correct participants based on the project roles and thread type.
+*   **Sending Messages**:
+    *   Admin messages in any thread type do not require approval and are immediately visible to all participants of that specific thread.
+*   **Message Moderation (for Type A threads)**:
+    *   In the "Client-Admin-Freelancer" (Type A) chat view, messages sent by Freelancers that are pending approval will be highlighted.
+    *   Admins have "Approve" and "Reject" options for these messages.
+        *   **Approved**: Message becomes visible to the Client and other participants in the Type A thread.
+        *   **Rejected**: Message remains hidden from the Client. The Freelancer sees the "Rejected" status.
+*   **Direct Messaging**:
+    *   Admins can initiate DMs with any Client, Freelancer, or other Admin via the general "Messages" page ("New Chat" modal will list all users).
+*   **File Exchange Links**:
+    *   In each project-specific chat view, a link/button to the relevant "Project Files" folder is displayed. The accessibility of the folder itself is managed by the file exchange system, but the link is provided contextually.
+
+### 2. Freelancer Workflow
+
+*   **Accessing Messages (`MessagingPage.tsx`)**:
+    *   Lists all threads the Freelancer is a participant in:
+        *   Direct Messages with Admins.
+        *   `project_admin_freelancer` (Type C) threads for their assigned projects.
+        *   `project_client_admin_freelancer` (Type A) threads for their assigned projects.
+*   **Direct Messaging (Restriction)**:
+    *   When initiating a "New Chat", the user list will **only show Admin users**. Freelancers cannot initiate DMs with Clients or other Freelancers.
+*   **Project Communication**:
+    *   **Type C (Admin-Freelancer)**: Can freely communicate with Admins.
+    *   **Type A (Client-Admin-Freelancer - "Observe & Participate with Approval")**:
+        *   Can view Admin messages and *approved* messages from the Client (and other approved freelancer messages if applicable).
+        *   When sending a message:
+            *   It automatically `requires_approval` and status is `pending`.
+            *   The Freelancer sees their own message with a "Pending Approval" status.
+            *   The message is NOT visible to the Client (or other freelancers) until an Admin approves it.
+            *   If approved by Admin, the message becomes visible to all Type A thread participants, and the status indicator updates for the Freelancer.
+            *   If rejected by Admin, the message remains hidden from others, and the Freelancer sees a "Rejected" status.
+*   **File Exchange Links**:
+    *   In Type A and Type C project threads, a link to the relevant "Project Files" folder is displayed.
+
+### 3. Client Workflow
+
+*   **Accessing Messages (`MessagingPage.tsx`)**:
+    *   Lists all threads the Client is a participant in:
+        *   Direct Messages with Admins.
+        *   `project_admin_client` (Type B) threads for their projects.
+        *   `project_client_admin_freelancer` (Type A) threads for their projects.
+*   **Direct Messaging (Restriction)**:
+    *   When initiating a "New Chat", the user list will **only show Admin users**. Clients cannot initiate DMs with Freelancers or other Clients.
+*   **Project Communication**:
+    *   **Type B (Admin-Client)**: Can freely communicate privately with Admins.
+    *   **Type A (Client-Admin-Freelancer)**:
+        *   Can view Admin messages and *approved* messages from Freelancers.
+        *   Messages sent by the Client in this thread do not require approval and are visible to Admin and Freelancer(s) (assuming freelancer has 'participant' role here).
+        *   Will NOT see Freelancer messages that are pending approval or have been rejected by an Admin.
+*   **File Exchange Links**:
+    *   In Type A and Type B project threads, a link to the relevant "Project Files" folder is displayed.
+
+## General UI Features
+
+*   WhatsApp-like styling for chat interfaces.
+*   Emoticon selector for adding reactions/emojis to messages.
+*   Real-time (or near real-time polling) updates for new messages and thread activity.
+*   Clear indication of unread messages.
+
+## Backend API Support (Key Revised/New Endpoints)
+
+*   **`get_messageable_users`**: Provides a filtered list of users for initiating DMs, enforcing restrictions for Freelancers/Clients.
+*   **`send_project_message`**: Handles creation of all three project thread types with correct participant setup and permissions (including setting `requires_approval` for Type A freelancer messages). Also handles sending messages to existing threads.
+*   **`get_thread_messages`**: Enforces strict visibility rules for messages based on user role, thread type, message approval status, and participant `visibility_level`.
+*   **`get_user_message_threads`**: Lists all accessible threads for the user.
+*   **`moderate_project_message`**: Allows Admins to approve/reject messages.
+
+This revised workflow provides more granular control over project communications and stricter direct messaging capabilities as per the updated requirements.


### PR DESCRIPTION
…flows

This commit implements a significant update to the messaging module to support projects with multiple assigned freelancers and incorporates detailed revisions to thread types, participant permissions, and Direct Message (DM) restrictions.

Key Changes:

1.  **Database Schema (`.multicoder/task/database_schema.md`):
    *   Replaced `projects.assigned_freelancer_id` with a new junction
        table `project_assigned_freelancers (project_id, user_id)` to
        enable multiple freelancers per project.
    *   Updated ENUMs and Foreign Key constraints in messaging tables
        (`message_threads`, `thread_participants`) to align with the new
        workflow requirements.

2.  **Backend API (`backend/api.php`):
    *   Heavily refactored `send_project_message`: When creating project-specific
        threads (Type A: Client-Admin-Freelancer(s), Type C: Admin-Freelancer(s)),
        the API now queries `project_assigned_freelancers` to include all
        assigned freelancers as participants.
    *   Implemented strict DM restrictions in `send_project_message`: Freelancers
        and Clients can only initiate DMs with Admin users.
    *   Created `get_messageable_users` endpoint to provide a filtered list of
        users for DM initiation, enforcing the above restrictions.
    *   Enhanced `get_thread_messages` to correctly filter message visibility
        in Type A threads with multiple freelancers (Clients see approved freelancer
        messages; Freelancers see relevant approved messages from others).
    *   Updated `get_user_message_threads` to ensure participant lists reflect
        multiple freelancers where applicable.

3.  **Frontend UI (`AdminProjectMessagingPage.tsx` & `MessagingPage.tsx`):
    *   Admin panel now correctly handles the three distinct project thread types,
        relying on the backend to manage multi-freelancer participation.
    *   `MessagingPage.tsx` (for Freelancers/Clients) uses `get_messageable_users`
        for its "New Chat" modal, restricting DM targets as per requirements.
    *   Message displays in both components will show sender information, naturally
        accommodating messages from different freelancers if the backend provides
        this data in the participant/message lists.
    *   File exchange links remain as simple UI elements pointing to conventional URLs.

4.  **Documentation:
    *   Updated `docs/messaging_workflow.md` and `backend/API_AUTH_DOCS.md` to
        detail the multi-freelancer capabilities, the three project thread types,
        DM restrictions, and API changes.